### PR TITLE
add equipment search fix and test

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -45,7 +45,9 @@ class SearchController < SessionsController
 
   def equipment
     sort_arr = sort_order
-    @repositories = Repository.where("equipment LIKE ?", "%#{params[:slug]}%").paginate(:per_page=>12,:page=>params[:page]) do
+
+    name = params[:slug].gsub('-', ' ')
+    @repositories =  Equipment.where(name: name).distinct.includes(:repository).map(&:repository).paginate(:per_page=>12,:page=>params[:page]) do
       order_by sort_arr.first, sort_arr.last
     end
 

--- a/app/views/search/equipment.html.erb
+++ b/app/views/search/equipment.html.erb
@@ -24,15 +24,13 @@
 
       <div class="repo-info">
         <div class="left">
-          <div class="title"><%= link_to repository.title, repository_path(repository.user_username, repository.slug) %></div> 
-          <div>by <%= link_to repository.user_username, user_path(repository.user_username) %></div> 
+          <div class="title"><%= link_to repository.title, repository_path(repository.user_username, repository.slug) %></div>
+          <div>by <%= link_to repository.user_username, user_path(repository.user_username) %></div>
           <div><%= time_ago_in_words(repository.created_at) << " ago" %></div>
         </div>
-        <div class="likes"><%= fa_icon 'heart' %><br><%= repository.like %></div> 
+        <div class="likes"><%= fa_icon 'heart' %><br><%= repository.like %></div>
       </div>
     </div>
   <% end %>
   </section>
-  <%= paginate @repositories %>
 </section>
-

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -28,4 +28,11 @@ class SearchControllerTest < ActionController::TestCase
     assert response.body.include? "Repository1"
   end
 
+  test "Shows repos by equipment" do
+    get :equipment, slug: '3d-printer'
+    assert_response :success
+    assert response.body.include? "Repository1"
+    refute response.body.include? "Repository2"
+  end
+
 end

--- a/test/fixtures/equipments.yml
+++ b/test/fixtures/equipments.yml
@@ -3,7 +3,7 @@
 one:
   id: 1
   repository_id: 1
-  name: 3D printer
+  name: 3d printer
 
 two:
   id: 2


### PR DESCRIPTION
Equipment search is broken in production. You can test by going to any repository and clicking on one of its equipment tags. 

The problem is that the query was checking the value of equipment column in Repository but that column doesn't exist.

In reality it's a `belongs_to :repository` and `has_many :equipment` association.  So I implemented a solution similar to what was done for categories. This seems to work in testing and development.

For this to work in production we'll have to map the slugs to the kind of equipments users can choose from on creating a repo. 

I got the list of equipments but i don't know about the letters casing (first letter capital or not etc). 