### PR TITLE
removed Repository.reindex

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -65,7 +65,6 @@ class RepositoriesController < SessionsController
       create_categories
       create_equipments
       render json: { redirect_uri: "#{repository_path(@user.username, @repository.slug)}" }
-      Repository.reindex
     else
       render json: @repository.errors["title"].first, status: :unprocessable_entity
     end
@@ -83,7 +82,6 @@ class RepositoriesController < SessionsController
       create_equipments
       flash[:notice] = "Project updated successfully!"
       render json: { redirect_uri: "#{repository_path(@repository.user_username, @repository.slug)}" }
-      Repository.reindex
     else
       render json: @repository.errors["title"].first, status: :unprocessable_entity
     end


### PR DESCRIPTION
@Parastoo-S caught a problem with creating new repos in production. An internal server error shows up after clicking save for the new repo (instead of redirect). However the repository gets created anyway.

The problem appears to be `Repository.reindex` leftover from solr at the end of `def create` in repositories_controller.

Removing this line fixes the error in development and should fix it in production. 
