### PR TITLE
Rake task to handle Brunsfield's training spreadsheet

### DIFF
--- a/lib/tasks/csv.rake
+++ b/lib/tasks/csv.rake
@@ -4,9 +4,9 @@ namespace :csv do
 
     $legible_users = []
 
-    data = Rails.root.join('test','lib','assets','TRAINING_DATABASE.csv')
+    test_spreadsheet = Rails.root.join('test','lib','assets','TRAINING_DATABASE.csv')
 
-    CSV.foreach(data) do |row|
+    CSV.foreach(test_spreadsheet) do |row|
 
       student_id = row[2]
       email = row[6]

--- a/lib/tasks/csv.rake
+++ b/lib/tasks/csv.rake
@@ -1,0 +1,34 @@
+namespace :csv do
+
+  task :legible_users => :environment do
+
+    $legible_users = []
+
+    data = Rails.root.join('test','lib','assets','TRAINING_DATABASE.csv')
+
+    CSV.foreach(data) do |row|
+
+      student_id = row[2]
+      email = row[6]
+      training = row[10]
+      trainer = row[13]
+
+      if student_id && training && trainer
+
+        if User.find_by(student_id: student_id).present?
+          $legible_users << User.find_by(student_id: student_id)
+        end
+        #TODO check if trainer and training exist
+
+      elsif email && training && trainer
+
+        if User.find_by(email: email).present?
+          $legible_users << User.find_by(email: email)
+        end
+        #TODO check if trainer and training exist
+
+      end
+    end
+  end
+
+end

--- a/test/lib/assets/TRAINING_DATABASE.csv
+++ b/test/lib/assets/TRAINING_DATABASE.csv
@@ -1,0 +1,3 @@
+T200057,https://drive.google.com/open?id=0B_aIWIFWmrUZdjlQRmFERjRnS3M,8413442,Zeyu Bo,Zeyu,Bo,boz966@uottawa.ca,Engineering,Mechanical Engineering,,Basic Training,5/13/2017,,David Clarke,GNG 2101,Z01,MTC,S1
+,,1234567,Bob,,,bob@gmail.com,,,,soldering_3,,,adam,,,,
+,,,olivia,,,olivia@gmail.com,,,,lathe_1,,,olivia,,,,

--- a/test/lib/csv_test.rb
+++ b/test/lib/csv_test.rb
@@ -1,0 +1,18 @@
+# test/lib/users_without_tac.rb
+require 'test_helper'
+require 'rake'
+
+load File.join(Rails.root, 'lib', 'tasks', 'csv.rake')
+
+class CsvTest < ActiveSupport::TestCase
+  setup do
+    @tasks = MakerSpaceRepo::Application.load_tasks
+    @task = Rake::Task['csv:legible_users'].invoke
+  end
+
+  test "bob and olivia are users with a student_id and/or email in our database" do
+      assert $legible_users.include? users(:bob)
+      assert $legible_users.include? users(:olivia)
+  end
+
+end


### PR DESCRIPTION
Parami shared with me a spreadsheet with 2100 records of training for people (mostly university students). 

In this branch I created a rake namespace called csv which contains tasks that check the legibility of certifying these users based on. To be legible they have to:

1. Exist as a makerepo user
2. The type of training they got exists in makerepo