### PR TITLE
Remove location from user

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -109,7 +109,7 @@ private
 
   def user_params
     params.require(:user).permit(:password, :password_confirmation, :url,
-      :location, :email, :name, :username, :avatar, :gender, :faculty, :use,
+      :email, :name, :username, :avatar, :gender, :faculty, :use,
       :description, :terms_and_conditions, :program, :student_id, :how_heard_about_us, :year_of_study, :identity)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -115,6 +115,12 @@ class User < ActiveRecord::Base
     end
   end
 
+  def location
+    if self.lab_sessions.last.equal? nil
+      return 'no sign in yet'
+    end
+    return self.lab_sessions.last.mac_address
+  end
 
   scope :in_last_month, -> { where('created_at BETWEEN ? AND ? ', 1.month.ago.beginning_of_month , 1.month.ago.end_of_month) }
 

--- a/app/views/settings/profile.html.erb
+++ b/app/views/settings/profile.html.erb
@@ -24,9 +24,6 @@
     <%= content_tag :span, @user.errors[:name].first, class: 'form-error' %>
     <%= f.text_field :name, class: "profile-text", autofocus: true %>
 
-    <%= f.label :location,"Location" , class: "profile-label" %>
-    <%= f.text_field :location, class: "profile-text" %>
-
     <%= f.label :url, "URL", class: "profile-label" %>
     <%= f.url_field :url, class: "profile-text" %>
 

--- a/app/views/staff/training_sessions/new.html.erb
+++ b/app/views/staff/training_sessions/new.html.erb
@@ -25,7 +25,7 @@
         <th>Select</th>
         <th>Username</th>
         <th>Last Signed In</th>
-        <th>tion</th>
+        <th>Location</th>
         <th>Certification</th>
       </tr>
 

--- a/app/views/staff/training_sessions/new.html.erb
+++ b/app/views/staff/training_sessions/new.html.erb
@@ -25,7 +25,7 @@
         <th>Select</th>
         <th>Username</th>
         <th>Last Signed In</th>
-        <th>Location</th>
+        <th>tion</th>
         <th>Certification</th>
       </tr>
 

--- a/db/migrate/20170808144303_remove_location_from_user.rb
+++ b/db/migrate/20170808144303_remove_location_from_user.rb
@@ -1,0 +1,5 @@
+class RemoveLocationFromUser < ActiveRecord::Migration
+  def change
+    remove_column :users, :location, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170808144303) do
+ActiveRecord::Schema.define(version: 20170808162101) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,8 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 20170717220935) do
+ActiveRecord::Schema.define(version: 20170808144303) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -154,6 +153,12 @@ ActiveRecord::Schema.define(version: 20170717220935) do
 
   add_index "rfids", ["user_id"], name: "index_rfids_on_user_id", using: :btree
 
+  create_table "spaces", force: :cascade do |t|
+    t.string   "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "training_sessions", force: :cascade do |t|
     t.integer  "training_id"
     t.integer  "user_id"
@@ -194,7 +199,6 @@ ActiveRecord::Schema.define(version: 20170717220935) do
     t.string   "username"
     t.string   "password"
     t.string   "url"
-    t.string   "location"
     t.datetime "created_at",                                    null: false
     t.datetime "updated_at",                                    null: false
     t.text     "description"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -153,12 +153,6 @@ ActiveRecord::Schema.define(version: 20170808144303) do
 
   add_index "rfids", ["user_id"], name: "index_rfids_on_user_id", using: :btree
 
-  create_table "spaces", force: :cascade do |t|
-    t.string   "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "training_sessions", force: :cascade do |t|
     t.integer  "training_id"
     t.integer  "user_id"

--- a/test/fixtures/lab_sessions.yml
+++ b/test/fixtures/lab_sessions.yml
@@ -3,21 +3,27 @@ one:
   sign_in_time: <%= 1.month.ago %>
   sign_out_time: 2017-06-21T13:25:01-04:00
   created_at: 2017-05-21T13:25:01-04:00
+  mac_address: a brunsfield pi
 
 two:
   user_id: 2
   sign_in_time: <%= 1.month.ago %>
   sign_out_time: 2017-06-21T13:25:01-04:00
   created_at: 2017-06-21T13:25:01-04:00
+  mac_address: a sandbox pi
+
 
 three:
   user_id: 777
   sign_in_time: 2017-07-23T13:25:01-04:00
   sign_out_time: 2017-07-23T13:25:01-04:00
   created_at: 2017-06-23T13:25:01-04:00
+  mac_address:  a brunsfield pi
+
 
 four:
     user_id: 2
     sign_in_time: <%= 1.month.ago %>
     sign_out_time: 2017-06-21T13:25:01-04:00
     created_at: 2017-06-21T13:25:01-04:00
+    mac_address: a makerspace pi

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -10,7 +10,6 @@ bob:
   terms_and_conditions: true
   password: $2a$10$CdKIia2HsjiFqYWtmDbV2ed4SY2Yn0oU.JdcIzPq09FSg71yZxIzq
   url: null
-  location: makerspace
   gender: male
   faculty: science
   use: null
@@ -30,7 +29,6 @@ mary:
   terms_and_conditions: true
   password: $2a$10$CdKIia2HsjiFqYWtmDbV2ed4SY2Yn0oU.JdcIzPq09FSg71yZxIzq
   url: null
-  location: sandbox
   gender: female
   faculty: engineering
   use: null
@@ -46,7 +44,6 @@ adam:
   terms_and_conditions: true
   password: $2a$10$CdKIia2HsjiFqYWtmDbV2ed4SY2Yn0oU.JdcIzPq09FSg71yZxIzq
   url: null
-  location: brunsfield
   gender: male
   faculty: arts
   use: null
@@ -62,7 +59,7 @@ sara:
   password: Password1
   identity: faculty_member
   gender: female
-  
+
 
 #the only staff
 olivia:
@@ -73,7 +70,6 @@ olivia:
   terms_and_conditions: true
   password: $2a$10$CdKIia2HsjiFqYWtmDbV2ed4SY2Yn0oU.JdcIzPq09FSg71yZxIzq
   url: null
-  location: makerspace
   gender: female
   faculty: engineering
   use: null


### PR DESCRIPTION
Removed the confusing 'location' column in the users table. 

Instead I wrote a `def location` method in `user.rb` which returns the mac_address (for now) of the user's last lab session.