### PR TITLE
compare lowercase attributes to lowercase query

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -63,7 +63,7 @@ class Admin::UsersController < AdminAreaController
         elsif params[:filter] == "Username"
           @users = User.where("LOWER(username) like LOWER(?)", "%#{@query}%").includes(:lab_sessions).order("#{params[:sort]} #{params[:direction]}").paginate(:page => params[:page], :per_page => 20)
         elsif !params[:filter].present?
-          @users = User.where('name like LOWER(?) OR email like LOWER(?) OR username like LOWER(?)', "%#{@query}%", "%#{@query}%", "%#{@query}%").includes(:lab_sessions).order("#{params[:sort]} #{params[:direction]}").paginate(:page => params[:page], :per_page => 20)
+          @users = User.where('LOWER(name) like LOWER(?) OR LOWER(email) like LOWER(?) OR LOWER(username) like LOWER(?)', "%#{@query}%", "%#{@query}%", "%#{@query}%").includes(:lab_sessions).order("#{params[:sort]} #{params[:direction]}").paginate(:page => params[:page], :per_page => 20)
         end
       else
         redirect_to (:back)

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -22,7 +22,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
   end
 
   test "admin can search for users by email" do
-    get :search, q: "@SARA.com"
+    get :search, q: "@SARA.com", filter: "Email"
     assert response.body.include? "Sara"
     refute response.body.include? "Mary"
   end

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -13,6 +13,18 @@ class Admin::UsersControllerTest < ActionController::TestCase
     patch :set_role, id: users(:mary), role: "staff"
     assert_equal User.find_by(username: "mary").role, "staff"
     assert_redirected_to admin_users_path
-    end
+  end
+
+  test "admin can search for users without filer" do
+    get :search, q: "mary"
+    assert response.body.include? "Mary"
+    refute response.body.include? "Sara"
+  end
+
+  test "admin can search for users by email" do
+    get :search, q: "@SARA.com"
+    assert response.body.include? "Sara"
+    refute response.body.include? "Mary"
+  end
 
 end


### PR DESCRIPTION
In production when you go to Admin Area -> Manage Users and try to search for a user it doesn't always show all matching results. 

Parastoo suggests it's because in this line 

`@users = User.where('name like LOWER(?) OR email like LOWER(?) OR username like LOWER(?)', "%#
{@query}%", "%#{@query}%", "%#{@query}%")...`

the query compares the users' attributes, which usually contain uppercase letters like in `name`, with `LOWER(query)`. 

**Solution**
Compare `LOWER(name)`  (and other user attribute) to `LOWER(query)`