### PR TITLE
Recieve rfid mac address

### DIFF
--- a/app/controllers/rfid_controller.rb
+++ b/app/controllers/rfid_controller.rb
@@ -33,7 +33,7 @@ class RfidController < SessionsController
     if active_session.present?
       active_sessions.update_all(sign_out_time: Time.now)
       last_active_location = PiReader.find_by(pi_mac_address: active_sessions.last.pi_reader.pi_mac_address)
-      if active_location != new_location
+      if last_active_location != new_location
         new_session(rfid, new_location)
       end
     else

--- a/app/controllers/rfid_controller.rb
+++ b/app/controllers/rfid_controller.rb
@@ -31,8 +31,8 @@ class RfidController < SessionsController
     active_session = rfid.user.lab_sessions.where("sign_out_time > ?", Time.now)
     if active_session.present?
       active_session.update_all(sign_out_time: Time.now)
-      active_location = PiReader.find_by(pi_mac_address: active_session.first.try(:mac_address)).try(:pi_location)
-      new_location = PiReader.find_by(pi_mac_address: params[:mac_address]).try(:pi_location)
+      active_location = PiReader.find_by(pi_mac_address: active_session.first.try(:mac_address))
+      new_location = PiReader.find_by(pi_mac_address: params[:mac_address])
       if active_location != new_location
         new_session(rfid)
       end
@@ -44,7 +44,7 @@ class RfidController < SessionsController
   def new_session (rfid)
     sign_in = Time.now
     sign_out = sign_in + 3.hours
-    raspi = PiReader.find_by(pi_mac_address: params[:mac_address]).try(params[:pi_location])
+    raspi = PiReader.find_by(pi_mac_address: params[:mac_address])
     new_session = rfid.user.lab_sessions.new(sign_in_time: sign_in, sign_out_time: sign_out, mac_address: params[:mac_address], pi_reader_id: raspi.id)
     new_session.save
   end

--- a/app/controllers/rfid_controller.rb
+++ b/app/controllers/rfid_controller.rb
@@ -30,7 +30,7 @@ class RfidController < SessionsController
   def check_session(rfid)
     active_sessions = rfid.user.lab_sessions.where("sign_out_time > ?", Time.now)
     new_location = PiReader.find_by(pi_mac_address: params[:mac_address])
-    if active_session.present?
+    if active_sessions.present?
       active_sessions.update_all(sign_out_time: Time.now)
       last_active_location = PiReader.find_by(pi_mac_address: active_sessions.last.pi_reader.pi_mac_address)
       if last_active_location != new_location

--- a/app/controllers/rfid_controller.rb
+++ b/app/controllers/rfid_controller.rb
@@ -32,7 +32,7 @@ class RfidController < SessionsController
     new_location = PiReader.find_by(pi_mac_address: params[:mac_address])
     if active_session.present?
       active_session.update_all(sign_out_time: Time.now)
-      active_location = PiReader.find_by(pi_mac_address: active_session.first.try(:mac_address))
+      active_location = PiReader.find_by(pi_mac_address: active_session.last.pi_reader.pi_mac_address)
       if active_location != new_location
         new_session(rfid, new_location)
       end

--- a/app/controllers/rfid_controller.rb
+++ b/app/controllers/rfid_controller.rb
@@ -1,12 +1,12 @@
 class RfidController < SessionsController
 
   def card_number
-    
+
     if !(PiReader.find_by(pi_mac_address: params[:mac_address]))
       new_reader = PiReader.new(pi_mac_address: params[:mac_address])
       new_reader.save
     end
-    
+
     rfid = Rfid.find_by(card_number: params[:rfid])
 
     if rfid
@@ -26,7 +26,7 @@ class RfidController < SessionsController
       end
     end
   end
-  
+
   def check_session(rfid)
     active_session = rfid.user.lab_sessions.where("sign_out_time > ?", Time.now)
     if active_session.present?
@@ -35,16 +35,17 @@ class RfidController < SessionsController
       new_location = PiReader.find_by(pi_mac_address: params[:mac_address]).try(:pi_location)
       if active_location != new_location
         new_session(rfid)
-      end   
+      end
     else
       new_session(rfid)
     end
   end
-  
+
   def new_session (rfid)
     sign_in = Time.now
     sign_out = sign_in + 3.hours
-    new_session = rfid.user.lab_sessions.new(sign_in_time: sign_in, sign_out_time: sign_out, mac_address: params[:mac_address])
+    raspi = PiReader.find_by(pi_mac_address: params[:mac_address]).try(params[:pi_location])
+    new_session = rfid.user.lab_sessions.new(sign_in_time: sign_in, sign_out_time: sign_out, mac_address: params[:mac_address], pi_reader_id: raspi.id)
     new_session.save
   end
 end

--- a/app/controllers/rfid_controller.rb
+++ b/app/controllers/rfid_controller.rb
@@ -44,8 +44,9 @@ class RfidController < SessionsController
   def new_session (rfid)
     sign_in = Time.now
     sign_out = sign_in + 3.hours
-    raspi = PiReader.find_by(pi_mac_address: params[:mac_address])
-    new_session = rfid.user.lab_sessions.new(sign_in_time: sign_in, sign_out_time: sign_out, mac_address: params[:mac_address], pi_reader_id: raspi.id)
-    new_session.save
+    if raspi = PiReader.find_by(pi_mac_address: params[:mac_address])
+      new_session = rfid.user.lab_sessions.new(sign_in_time: sign_in, sign_out_time: sign_out, mac_address: params[:mac_address], pi_reader_id: raspi.id)
+      new_session.save
+    end
   end
 end

--- a/app/controllers/rfid_controller.rb
+++ b/app/controllers/rfid_controller.rb
@@ -28,11 +28,11 @@ class RfidController < SessionsController
   end
 
   def check_session(rfid)
-    active_session = rfid.user.lab_sessions.where("sign_out_time > ?", Time.now)
+    active_sessions = rfid.user.lab_sessions.where("sign_out_time > ?", Time.now)
     new_location = PiReader.find_by(pi_mac_address: params[:mac_address])
     if active_session.present?
-      active_session.update_all(sign_out_time: Time.now)
-      active_location = PiReader.find_by(pi_mac_address: active_session.last.pi_reader.pi_mac_address)
+      active_sessions.update_all(sign_out_time: Time.now)
+      last_active_location = PiReader.find_by(pi_mac_address: active_sessions.last.pi_reader.pi_mac_address)
       if active_location != new_location
         new_session(rfid, new_location)
       end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170808162101) do
+ActiveRecord::Schema.define(version: 20170823161336) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/test/controllers/rfid_controller_test.rb
+++ b/test/controllers/rfid_controller_test.rb
@@ -15,7 +15,7 @@ class RfidControllerTest < ActionController::TestCase
   end
 
   test "posting new rfid returns unprocessable_entity" do
-    post :card_number, rfid: "completly new"
+    post :card_number, rfid: "completly new", mac_address: "m4k3rsp4c3-pi-1"
 
     assert_response :unprocessable_entity
   end
@@ -24,24 +24,24 @@ class RfidControllerTest < ActionController::TestCase
     rfid = rfids(:old)
 
     assert_no_difference('Rfid.count') do
-      post :card_number, rfid: rfid.card_number
+      post :card_number, rfid: rfid.card_number, mac_address: "m4k3rsp4c3-pi-1"
     end
   end
 
   test "posting existing card with no user updates updated_at" do
-    rfid = rfids(:old)
+    rfid = rfids(:no_user)
     old_timestamp = rfid.updated_at.to_i
 
-    post :card_number, rfid: rfid.card_number
+    post :card_number, rfid: rfid.card_number, mac_address: "8runsf13ld-pi-1"
 
     rfid.reload
     assert_not_equal old_timestamp, rfid.updated_at.to_i
   end
 
   test "posting existing card with no user returns unprocessable_entity" do
-    rfid = rfids(:old)
+    rfid = rfids(:no_user)
 
-    post :card_number, rfid: rfid.card_number
+    post :card_number, rfid: rfid.card_number, mac_address: "8runsf13ld-pi-1"
 
     assert_response :unprocessable_entity
   end
@@ -49,7 +49,7 @@ class RfidControllerTest < ActionController::TestCase
   test "posting existing card with user returns ok" do
     rfid = rfids(:assigned)
 
-    post :card_number, rfid: rfid.card_number
+    post :card_number, rfid: rfid.card_number, mac_address: "m4k3rsp4c3-pi-1"
 
     assert_response :ok
   end

--- a/test/controllers/rfid_controller_test.rb
+++ b/test/controllers/rfid_controller_test.rb
@@ -62,4 +62,16 @@ class RfidControllerTest < ActionController::TestCase
     assert PiReader.find_by(pi_mac_address: rfid.mac_address, space_id: nil).present?
   end
 
+  test "can sign in to a space" do
+    rfid = rfids(:assigned)
+    raspi =  pi_readers(:two)
+
+    post :card_number, rfid: rfid.card_number, mac_address: raspi.pi_mac_address
+
+    lab_session = LabSession.find_by(user_id: rfid.user_id, pi_readrer_id: raspi.pi_mac_address)
+    assert lab_session.present?
+    assert lab_session.sign_out_time > Time.now
+    assert raspi.space.signed_in_users.include? rfid.user
+  end
+
 end

--- a/test/controllers/rfid_controller_test.rb
+++ b/test/controllers/rfid_controller_test.rb
@@ -24,7 +24,7 @@ class RfidControllerTest < ActionController::TestCase
     rfid = rfids(:old)
 
     assert_no_difference('Rfid.count') do
-      post :card_number, rfid: rfid.card_number, mac_address: "m4k3rsp4c3-pi-1"
+      post :card_number, rfid: rfid.card_number, mac_address: rfid.mac_address
     end
   end
 
@@ -32,7 +32,7 @@ class RfidControllerTest < ActionController::TestCase
     rfid = rfids(:no_user)
     old_timestamp = rfid.updated_at.to_i
 
-    post :card_number, rfid: rfid.card_number, mac_address: "8runsf13ld-pi-1"
+    post :card_number, rfid: rfid.card_number, mac_address: rfid.mac_address
 
     rfid.reload
     assert_not_equal old_timestamp, rfid.updated_at.to_i
@@ -41,7 +41,7 @@ class RfidControllerTest < ActionController::TestCase
   test "posting existing card with no user returns unprocessable_entity" do
     rfid = rfids(:no_user)
 
-    post :card_number, rfid: rfid.card_number, mac_address: "8runsf13ld-pi-1"
+    post :card_number, rfid: rfid.card_number, mac_address: rfid.mac_address
 
     assert_response :unprocessable_entity
   end
@@ -53,4 +53,13 @@ class RfidControllerTest < ActionController::TestCase
 
     assert_response :ok
   end
+
+  test "posting from a newly connected pi creates a new PiReader with no space_id" do
+    rfid = rfids(:from_new_pi)
+
+    post :card_number, rfid: rfid.card_number, mac_address: rfid.mac_address
+
+    assert PiReader.find_by(pi_mac_address: rfid.mac_address, space_id: nil).present?
+  end
+
 end

--- a/test/controllers/rfid_controller_test.rb
+++ b/test/controllers/rfid_controller_test.rb
@@ -68,9 +68,9 @@ class RfidControllerTest < ActionController::TestCase
 
     post :card_number, rfid: rfid.card_number, mac_address: raspi.pi_mac_address
 
-    lab_session = LabSession.find_by(user_id: rfid.user_id, pi_readrer_id: raspi.pi_mac_address)
+    lab_session = LabSession.find_by(user_id: rfid.user_id, pi_reader_id: raspi.id)
+    
     assert lab_session.present?
-    assert lab_session.sign_out_time > Time.now
     assert raspi.space.signed_in_users.include? rfid.user
   end
 

--- a/test/fixtures/rfids.yml
+++ b/test/fixtures/rfids.yml
@@ -20,3 +20,10 @@ no_user:
   created_at: <%= Time.now - 10.days %>
   updated_at: <%= Time.now - 10.days %>
   mac_address: 8runsf13ld-pi-1
+
+from_new_pi:
+  user_id:
+  card_number: "23012"
+  created_at: <%= Time.now - 3.days %>
+  updated_at: <%= Time.now - 2.days %>
+  mac_address: n3w-m4c-4dr3ss

--- a/test/fixtures/rfids.yml
+++ b/test/fixtures/rfids.yml
@@ -1,13 +1,22 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 old:
-  user_id:
+  user_id: 1
   card_number: "123456789"
   created_at: <%= Time.now - 30.days %>
   updated_at: <%= Time.now - 30.days %>
+  mac_address: m4k3rsp4c3-pi-1
 
 assigned:
-  user_id: 1
+  user_id: 2
   card_number: "987654321"
   created_at: <%= Time.now - 20.days %>
   updated_at: <%= Time.now - 20.days %>
+  mac_address: m4k3rsp4c3-pi-1
+
+no_user:
+  user_id:
+  card_number: "000111222"
+  created_at: <%= Time.now - 10.days %>
+  updated_at: <%= Time.now - 10.days %>
+  mac_address: 8runsf13ld-pi-1


### PR DESCRIPTION
removed `try(:pi_location)` because `pi_reader.pi_location` is now being replaced with `pi_reader.space.name` using the `PiReader belongs_to :space` association.