### PR TITLE
no more warning

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -26,7 +26,7 @@ class Repository < ActiveRecord::Base
     uniqueness: { message: "Project title is already in use.", scope: :user_username}
 
   validates :photos,
-  :length => { :minimum => 1 }, on: [:create, :update],
+  :length => { :minimum => 1 },
   :presence => {message: "At least one photo is required"}, on: [:create, :update]
 
   before_save do


### PR DESCRIPTION
got rid of repeated `on: [:create, :update]` in `repository.rb` :

> validates :photos,
  :length => { :minimum => 1 }, ~on: [:create, :update]~
  :presence => {message: "At least one photo is required"}, on: [:create, :update]