### PR TITLE
make the switch

### DIFF
--- a/app/controllers/rfid_controller.rb
+++ b/app/controllers/rfid_controller.rb
@@ -32,7 +32,7 @@ class RfidController < SessionsController
     new_location = PiReader.find_by(pi_mac_address: params[:mac_address])
     if active_sessions.present?
       active_sessions.update_all(sign_out_time: Time.now)
-      last_active_location = PiReader.find_by(pi_mac_address: active_sessions.last.pi_reader.pi_mac_address)
+      last_active_location = PiReader.find_by(space_id: active_sessions.last.space.id)
       if last_active_location != new_location
         new_session(rfid, new_location)
       end
@@ -44,7 +44,7 @@ class RfidController < SessionsController
   def new_session (rfid, new_location)
     sign_in = Time.now
     sign_out = sign_in + 3.hours
-    new_session = rfid.user.lab_sessions.new(sign_in_time: sign_in, sign_out_time: sign_out, mac_address: params[:mac_address], pi_reader_id: new_location.id)
+    new_session = rfid.user.lab_sessions.new(sign_in_time: sign_in, sign_out_time: sign_out, mac_address: params[:mac_address], space_id: new_location.space.id)
     new_session.save
   end
 end

--- a/app/models/lab_session.rb
+++ b/app/models/lab_session.rb
@@ -1,7 +1,6 @@
 class LabSession < ActiveRecord::Base
   belongs_to :user
-  belongs_to :pi_reader
-  has_one :space, through: :pi_reader
+  belongs_to :space
 
   scope :between_dates_picked, ->(start_date , end_date){ where('created_at BETWEEN ? AND ? ', start_date , end_date) }
 

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -1,6 +1,6 @@
 class Space < ActiveRecord::Base
   has_many :pi_readers
-  has_many :lab_sessions, through: :pi_readers
+  has_many :lab_sessions, dependent: :destroy
   has_many :users, through: :lab_sessions
   has_many :trainings, dependent: :destroy
   has_many :training_sessions, through: :trainings

--- a/db/migrate/20170830191824_add_space_to_lab_sessions.rb
+++ b/db/migrate/20170830191824_add_space_to_lab_sessions.rb
@@ -1,0 +1,5 @@
+class AddSpaceToLabSessions < ActiveRecord::Migration
+  def change
+    add_reference :lab_sessions, :space, index: true, foreign_key: true
+  end
+end

--- a/db/migrate/20170830191857_remove_pi_reader_from_lab_sessions.rb
+++ b/db/migrate/20170830191857_remove_pi_reader_from_lab_sessions.rb
@@ -1,0 +1,5 @@
+class RemovePiReaderFromLabSessions < ActiveRecord::Migration
+  def change
+    remove_reference :lab_sessions, :pi_reader, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170823161336) do
+ActiveRecord::Schema.define(version: 20170830191857) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,10 +77,10 @@ ActiveRecord::Schema.define(version: 20170823161336) do
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
     t.string   "mac_address"
-    t.integer  "pi_reader_id"
+    t.integer  "space_id"
   end
 
-  add_index "lab_sessions", ["pi_reader_id"], name: "index_lab_sessions_on_pi_reader_id", using: :btree
+  add_index "lab_sessions", ["space_id"], name: "index_lab_sessions_on_space_id", using: :btree
   add_index "lab_sessions", ["user_id"], name: "index_lab_sessions_on_user_id", using: :btree
 
   create_table "likes", force: :cascade do |t|
@@ -236,7 +236,7 @@ ActiveRecord::Schema.define(version: 20170823161336) do
   add_foreign_key "comments", "repositories"
   add_foreign_key "comments", "users"
   add_foreign_key "equipment", "repositories"
-  add_foreign_key "lab_sessions", "pi_readers"
+  add_foreign_key "lab_sessions", "spaces"
   add_foreign_key "likes", "repositories"
   add_foreign_key "likes", "users"
   add_foreign_key "photos", "repositories"

--- a/test/controllers/rfid_controller_test.rb
+++ b/test/controllers/rfid_controller_test.rb
@@ -68,8 +68,8 @@ class RfidControllerTest < ActionController::TestCase
 
     post :card_number, rfid: rfid.card_number, mac_address: raspi.pi_mac_address
 
-    lab_session = LabSession.find_by(user_id: rfid.user_id, pi_reader_id: raspi.id)
-    
+    lab_session = LabSession.find_by(user_id: rfid.user_id, space_id: raspi.space.id)
+
     assert lab_session.present?
     assert raspi.space.signed_in_users.include? rfid.user
   end

--- a/test/fixtures/lab_sessions.yml
+++ b/test/fixtures/lab_sessions.yml
@@ -1,6 +1,6 @@
 one:
   user_id: 1
-  pi_reader_id: 1
+  space_id: 1
   sign_in_time: <%= 1.month.ago %>
   sign_out_time: 2017-06-21T13:25:01-04:00
   created_at: 2017-05-21T13:25:01-04:00
@@ -9,7 +9,7 @@ one:
 
 two:
   user_id: 2
-  pi_reader_id: 2
+  space_id: 2
   sign_in_time: <%= 1.month.ago %>
   sign_out_time: 2017-06-21T13:25:01-04:00
   created_at: 2017-06-21T13:25:01-04:00
@@ -17,25 +17,16 @@ two:
 
 three:
   user_id: 777
-  pi_reader_id: 2
+  space_id: 2
   sign_in_time: 2017-07-23T13:25:01-04:00
   sign_out_time: 2017-07-23T13:25:01-04:00
   created_at: 2017-06-23T13:25:01-04:00
   mac_address: 8runsf13ld-pi-1
 
 
-
 four:
   user_id: 2
-  pi_reader_id: 2
-  sign_in_time: <%= 1.month.ago %>
-  sign_out_time: 2017-06-21T13:25:01-04:00
-  created_at: 2017-06-21T13:25:01-04:00
-  mac_address: 8runsf13ld-pi-1
-
-four:
-  user_id: 2
-  pi_reader_id: 1
+  space_id: 1
   sign_in_time: <%= 1.hour.ago %>
   sign_out_time: <%= Date.tomorrow %>
   created_at: 2017-06-21T13:25:01-04:00
@@ -43,7 +34,7 @@ four:
 
 five:
   user_id: 1337
-  pi_reader_id: 1
+  space_id: 1
   sign_in_time: <%= 2.hours.ago %>
   sign_out_time: <%= Date.tomorrow %>
   created_at: 2017-08-17T09:30:01-04:00

--- a/test/models/space_test.rb
+++ b/test/models/space_test.rb
@@ -6,7 +6,7 @@ class SpaceTest < ActiveSupport::TestCase
     refute spaces(:brunsfield).users.include? user
     #creating a lab session with a pi_reader that belongs_to brunsfield
     #makse Sara signed in to brunsfield
-    LabSession.create(user_id: user.id, pi_reader_id: 2)
+    LabSession.create(user_id: user.id, space_id: 2)
     assert spaces(:brunsfield).users.include? user
   end
 

--- a/test/models/space_test.rb
+++ b/test/models/space_test.rb
@@ -4,8 +4,6 @@ class SpaceTest < ActiveSupport::TestCase
   test "User-Space association through LabSession and PiReader" do
     user = users(:sara)
     refute spaces(:brunsfield).users.include? user
-    #creating a lab session with a pi_reader that belongs_to brunsfield
-    #makse Sara signed in to brunsfield
     LabSession.create(user_id: user.id, space_id: 2)
     assert spaces(:brunsfield).users.include? user
   end


### PR DESCRIPTION
I realized that the association between `LabSession` and `Space` shouldn't be `through: :pi_readers`.

This is Because if a `PiReader` get associated with a different `Space` then it shouldn't associate old `LabSessions` with that space too.

This PR introduces the necessary changes to have a `:belongs_to` / `:has_many` association between `Space` and `LabSession`

And actually this means that there's no need for `LabSession belongs_to:  :pi_reader` and so I removed that association. 