### PR TITLE
Let staff set rfid

### DIFF
--- a/app/assets/stylesheets/user_show.scss
+++ b/app/assets/stylesheets/user_show.scss
@@ -95,6 +95,32 @@ section#user-show{
 	}
 }
 
+div#rfid-thing.user-info{
+
+	div#rfid-details{
+		visibility: hidden;
+		background-color: #c2d6d6;
+		color: #366;
+		text-align: center;
+		border-radius: 6px;
+		padding-bottom: 2px;
+		/* Position the tooltip */
+		position: absolute;
+		z-index: 1;
+
+	}
+
+	div.rfid-status{
+	  cursor:pointer;
+	}
+
+	div.rfid-status:hover div#rfid-details{
+	    visibility:visible;
+	}
+	div.unregistered-card:hover{
+		background-color: transparentize(#c2d6d6, 0.5);;
+	}
+}
 a.edit-user-profile{
 	@include transition(100ms);
 	position: absolute;

--- a/app/assets/stylesheets/user_show.scss
+++ b/app/assets/stylesheets/user_show.scss
@@ -96,18 +96,23 @@ section#user-show{
 }
 
 div#rfid-thing.user-info{
-
+	width: 400px;
 	div#rfid-details{
 		visibility: hidden;
 		background-color: #c2d6d6;
 		color: #366;
 		text-align: center;
-		border-radius: 6px;
-		padding-bottom: 2px;
+		border-radius: 4px;
+		padding: 4px;
 		/* Position the tooltip */
 		position: absolute;
 		z-index: 1;
+		width: inherit + 3%;
 
+		label.unregistered-label{
+			padding: 5px 8px;
+			border-radius: 3px;
+		}
 	}
 
 	div.rfid-status{
@@ -117,10 +122,37 @@ div#rfid-thing.user-info{
 	div.rfid-status:hover div#rfid-details{
 	    visibility:visible;
 	}
-	div.unregistered-card:hover{
-		background-color: transparentize(#c2d6d6, 0.5);;
+	div.unregistered-card{
+
+		a{
+			padding: 4px 8px;
+		}
+		a:hover{
+			border-radius: 4px;
+			background-color: transparentize(#A6E0E7, 0.4);
+		}
 	}
+
+	span.registered-card{
+		float: left;
+	}
+
+	.unregister{
+		font: 300 0.4em 'Raleway', sans-serif;
+		float: bottom;
+	  padding: 0.5rem 1rem;
+	  border: none;
+	  text-transform: uppercase;
+	  color: #777;
+	  letter-spacing: 0.11em;
+	  border-radius: 2px;
+	  background-color: #A61E10;
+	  color: #fff;
+	}
+
 }
+
+
 a.edit-user-profile{
 	@include transition(100ms);
 	position: absolute;

--- a/app/assets/stylesheets/user_show.scss
+++ b/app/assets/stylesheets/user_show.scss
@@ -107,7 +107,7 @@ div#rfid-thing.user-info{
 		/* Position the tooltip */
 		position: absolute;
 		z-index: 1;
-		width: inherit + 3%;
+		width: 102%;
 
 		label.unregistered-label{
 			padding: 5px 8px;

--- a/app/assets/stylesheets/user_show.scss
+++ b/app/assets/stylesheets/user_show.scss
@@ -120,7 +120,7 @@ div#rfid-thing.user-info{
 	}
 
 	div.rfid-status:hover div#rfid-details{
-	    visibility:visible;
+	    visibility: visible;
 	}
 	div.unregistered-card{
 

--- a/app/assets/stylesheets/user_show.scss
+++ b/app/assets/stylesheets/user_show.scss
@@ -107,7 +107,6 @@ div#rfid-thing.user-info{
 		/* Position the tooltip */
 		position: absolute;
 		z-index: 1;
-		width: 102%;
 
 		label.unregistered-label{
 			padding: 5px 8px;

--- a/app/controllers/rfid_controller.rb
+++ b/app/controllers/rfid_controller.rb
@@ -14,8 +14,9 @@ class RfidController < SessionsController
         render json: { success: "RFID exist" }, status: :ok
         check_session(rfid)
       else
-        rfid.update(mac_address: params[:mac_address])
+        rfid.mac_address = params[:mac_address]
         rfid.touch
+        rfid.save
         render json: { error: "Temporary RFID already exists" }, status: :unprocessable_entity
       end
     else

--- a/app/controllers/rfid_controller.rb
+++ b/app/controllers/rfid_controller.rb
@@ -14,7 +14,8 @@ class RfidController < SessionsController
         render json: { success: "RFID exist" }, status: :ok
         check_session(rfid)
       else
-        rfid.update(params)
+        rfid.update(mac_address: params[:mac_address])
+        rfid.touch
         render json: { error: "Temporary RFID already exists" }, status: :unprocessable_entity
       end
     else

--- a/app/controllers/rfid_controller.rb
+++ b/app/controllers/rfid_controller.rb
@@ -14,7 +14,7 @@ class RfidController < SessionsController
         render json: { success: "RFID exist" }, status: :ok
         check_session(rfid)
       else
-        rfid.touch
+        rfid.update(params)
         render json: { error: "Temporary RFID already exists" }, status: :unprocessable_entity
       end
     else

--- a/app/controllers/staff_dashboard_controller.rb
+++ b/app/controllers/staff_dashboard_controller.rb
@@ -16,7 +16,10 @@ class StaffDashboardController < StaffAreaController
     if params['card_number'].present?
       rfid = Rfid.find_by(card_number: params['card_number'])
       rfid.user_id = nil
-      rfid.mac_address = Space.find_by(name: @user.location).pi_readers.first.pi_mac_address rescue rfid.mac_address
+      if pi = Space.find_by(name: @user.location).pi_readers.first
+        new_mac = pi.pi_mac_address
+        rfid.mac_address = new_mac
+      end
       rfid.save
     end
     redirect_to :back

--- a/app/controllers/staff_dashboard_controller.rb
+++ b/app/controllers/staff_dashboard_controller.rb
@@ -4,7 +4,6 @@ class StaffDashboardController < StaffAreaController
   end
 
   def link_rfid
-    binding.pry
     if params['user_id'].present? && params['card_number'].present?
       rfid = Rfid.find_by(card_number: params['card_number'])
       rfid.user_id = params['user_id']

--- a/app/controllers/staff_dashboard_controller.rb
+++ b/app/controllers/staff_dashboard_controller.rb
@@ -12,4 +12,14 @@ class StaffDashboardController < StaffAreaController
     redirect_to :back
   end
 
+  def unlink_rfid
+    if params['card_number'].present?
+      rfid = Rfid.find_by(card_number: params['card_number'])
+      rfid.user_id = nil
+      rfid.mac_address = Space.find_by(name: @user.location).pi_readers.first.pi_mac_address rescue rfid.mac_address
+      rfid.save
+    end
+    redirect_to :back
+  end
+
 end

--- a/app/controllers/staff_dashboard_controller.rb
+++ b/app/controllers/staff_dashboard_controller.rb
@@ -3,4 +3,14 @@ class StaffDashboardController < StaffAreaController
   def index
   end
 
+  def link_rfid
+    binding.pry
+    if params['user_id'].present? && params['card_number'].present?
+      rfid = Rfid.find_by(card_number: params['card_number'])
+      rfid.user_id = params['user_id']
+      rfid.save
+    end
+    redirect_to :back
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -115,7 +115,7 @@ class User < ActiveRecord::Base
     if self.lab_sessions.last.equal? nil
       return 'no sign in yet'
     end
-    return self.lab_sessions.last.mac_address
+    return self.lab_sessions.last.space.name
   end
 
   scope :unsigned_tac_users, -> { where('terms_and_conditions = false') }

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -82,7 +82,6 @@
                 <%= fa_icon "sort-#{direction}" %>
               <% end %>
             </th>
-            <th>Edit</th>
             <th>View</th>
           </thead>
           <% @users.each do |user| %>
@@ -99,7 +98,6 @@
                 <% end %>
               </td>
               <td><%= time_ago_in_words(user.created_at) %> ago</td>
-			           <td class="link-table"><%= link_to fa_icon("pencil"), edit_admin_user_path(user) %></td>
               <td class="link-table"><%= link_to fa_icon("search"), admin_user_path(user) %></td>
             </tr>
           <% end %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -5,7 +5,6 @@
 <div class="user-show-admin">
 <section id="user-show-admin">
   <div id="user-info">
-    <%= link_to fa_icon("pencil", text: 'Edit user'), edit_admin_user_path(@edit_admin_user), class: 'edit-user-link' %>
       <div class="user-avatar">
         <%= image_tag @edit_admin_user.avatar.url, class: 'edit-avatar'%>
         <% if @all_sessions.where("sign_out_time > ?", Time.now).present? %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -61,7 +61,7 @@
         <div class="rfid-status">
           <%= fa_icon "check", text: "RFID Card Set"%>
           <div id="rfid-details">
-             <span class="registered-card" style="display:inline;widh">
+             <span class="registered-card" style="display:inline;">
                <%= label_tag ("card #:#{@repo_user.rfid.card_number}")%></span>
             <span><%=
                link_to 'unregister',
@@ -72,8 +72,11 @@
       <div class="rfid-status">
         <%= fa_icon "ban", text: "RFID Card Not Set"%>
         <div id="rfid-details">
-          <label class="unregistered-label"><b>Unregistered Cards</b><br><i style="font-size:0.8em;">&ensp;&ensp;&ensp;&ensp;&ensp;
-            (click on one to link it to this user)</i></label><br>
+          <label class="unregistered-label">
+            <b>Unregistered Cards</b>
+          </label>
+          <br><i style="font-size:0.8em;">&ensp;&ensp;&ensp;&ensp;&ensp;
+            (click on one to link it to this user)</i><br>
           <% Rfid.recent_unset.each do |rfid| %>
             <div class="unregistered-card">
               <%space = PiReader.find_by(pi_mac_address: rfid.mac_address).space.name rescue "unknown" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -56,6 +56,31 @@
 
 
     <% if @user.staff?%>
+    <div class="user-info" id="rfid-thing">
+      <% if @repo_user.rfid.present?%>
+        <div class="rfid-status">
+          <%= fa_icon "check", text: "RFID Card Set"%>
+          <div id="rfid-details">
+            card #: <%= @repo_user.rfid.card_number %>
+          </div>
+        </div>
+      <%else%>
+      <div class="rfid-status">
+        <%= fa_icon "ban", text: "RFID Card Not Set"%>
+        <div id="rfid-details">
+          <% Rfid.recent_unset.each do |rfid| %>
+            <div class="unregistered-card">
+              <%space = PiReader.find_by(pi_mac_address: rfid.mac_address).space.name rescue "unknown" %>
+                <%=
+                link_to (rfid.card_number + " tapped at #{space} about " + time_ago_in_words(rfid.updated_at) + " ago"),
+                staff_dashboard_link_rfid_path(user_id: @repo_user.id, card_number: rfid.card_number), action: :link_rfid, method: :put
+                %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+      <%end%>
+    </div>
       <br></br>
       <div class="user-certifications" style="padding-top: 200px;">This user has the following certifications:
         <br></br>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -61,18 +61,24 @@
         <div class="rfid-status">
           <%= fa_icon "check", text: "RFID Card Set"%>
           <div id="rfid-details">
-            card #: <%= @repo_user.rfid.card_number %>
+             <span class="registered-card" style="display:inline;widh">
+               <%= label_tag ("card #:#{@repo_user.rfid.card_number}")%></span>
+            <span><%=
+               link_to 'unregister',
+               staff_dashboard_unlink_rfid_path(card_number: @repo_user.rfid.card_number), action: :link_rfid, method: :put, class: 'unregister' %>
           </div>
         </div>
       <%else%>
       <div class="rfid-status">
         <%= fa_icon "ban", text: "RFID Card Not Set"%>
         <div id="rfid-details">
+          <label class="unregistered-label"><b>Unregistered Cards</b><br><i style="font-size:0.8em;">&ensp;&ensp;&ensp;&ensp;&ensp;
+            (click on one to link it to this user)</i></label><br>
           <% Rfid.recent_unset.each do |rfid| %>
             <div class="unregistered-card">
               <%space = PiReader.find_by(pi_mac_address: rfid.mac_address).space.name rescue "unknown" %>
                 <%=
-                link_to (rfid.card_number + " tapped at #{space} about " + time_ago_in_words(rfid.updated_at) + " ago"),
+                link_to (rfid.card_number + " tapped at #{space} " + time_ago_in_words(rfid.updated_at) + " ago"),
                 staff_dashboard_link_rfid_path(user_id: @repo_user.id, card_number: rfid.card_number), action: :link_rfid, method: :put
                 %>
             </div>
@@ -148,6 +154,7 @@
       </div>
     <% end %>
   </div>
+
 
   <section id="user-show-links">
     <% active = params[:show].eql?("makes") ? ["#eee", "#5f9ea0"] : ["#5f9ea0", "#eee"] %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -150,6 +150,7 @@ Rails.application.routes.draw do
   namespace :staff_dashboard do
     get 'index', path: '/'
     put 'link_rfid'
+    put 'unlink_rfid'
   end
 
   # namespace :help do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,6 +149,7 @@ Rails.application.routes.draw do
 
   namespace :staff_dashboard do
     get 'index', path: '/'
+    put 'link_rfid'
   end
 
   # namespace :help do

--- a/test/controllers/staff_dashboard_controller_test.rb
+++ b/test/controllers/staff_dashboard_controller_test.rb
@@ -21,9 +21,19 @@ class StaffDashboardControllerTest < ActionController::TestCase
      session[:expires_at] = "Sat, 03 Jun 2025 05:01:41 UTC +00:00"
      @request.env['HTTP_REFERER'] = user_url(users(:sara))
      rfid = rfids(:old)
-     get :link_rfid, card_number: rfid.card_number, user_id: users(:sara)
+     put :link_rfid, card_number: rfid.card_number, user_id: users(:sara)
      assert_redirected_to :back
      assert users(:sara).rfid.present?
+   end
+
+   test "staff can unlink rfid from a user" do
+     session[:user_id] = users(:olivia).id
+     session[:expires_at] = "Sat, 03 Jun 2025 05:01:41 UTC +00:00"
+     @request.env['HTTP_REFERER'] = user_url(users(:sara))
+     rfid = rfids(:assigned)
+     put :unlink_rfid, card_number: rfid.card_number, user_id: users(:sara)
+     assert_redirected_to :back
+     refute users(:mary).rfid.present?
    end
 
 end

--- a/test/controllers/staff_dashboard_controller_test.rb
+++ b/test/controllers/staff_dashboard_controller_test.rb
@@ -16,4 +16,14 @@ class StaffDashboardControllerTest < ActionController::TestCase
      assert_redirected_to root_path
    end
 
+   test "staff can link rfid to a user" do
+     session[:user_id] = users(:olivia).id
+     session[:expires_at] = "Sat, 03 Jun 2025 05:01:41 UTC +00:00"
+     @request.env['HTTP_REFERER'] = user_url(users(:sara))
+     rfid = rfids(:old)
+     get :link_rfid, card_number: rfid.card_number, user_id: users(:sara)
+     assert_redirected_to :back
+     assert users(:sara).rfid.present?
+   end
+
 end


### PR DESCRIPTION
This PR includes controller actions to `staff_dashboard_controller` to associate/dissociate an `Rfid` to a `User`.

Additionally, I removed links to edit_admin_user_url because:

a) the actions in the view are now available in other views under the Staff thing.
b) the update action is out of date and does things like delete all user certs (based on old certification concept)

so it's safest to remove access to that view even for admins

