### PR TITLE
Removed Length validation for student ID

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,9 +52,7 @@ class User < ActiveRecord::Base
     presence: {message: "Please provide your year of study"}, if: :student?
 
   validates :student_id,
-    presence: {message: "Please provide your student Number"}, if: :student?,
-    length: { is: 7, message: 'Your student number must be 7 characters.' }
-
+    presence: {message: "Please provide your student Number"}, if: :student?
 
   validates :identity,
     presence: {message: "Please identify who you are"},

--- a/app/views/settings/profile.html.erb
+++ b/app/views/settings/profile.html.erb
@@ -265,7 +265,7 @@ l’Événement.
         <p> If you are <strong>not</strong> a <strong> student </strong>, you can ignore the rest of the form and click Save. </p>
         <p> If you <strong>are</strong> a student (grad/undergrad) it is mandatory for you to answer the questions below. </p>
 
-        <%= f.label :student_id , "Student Number (must be 7 characters)" , class: "profile-label"%>
+        <%= f.label :student_id , "Student Number" , class: "profile-label"%>
         <%= content_tag :span, @user.errors[:student_id].first, class: 'form-error' %>
         <%= f.text_field :student_id, class: "profile-text", autofocus: true %>
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -174,15 +174,6 @@ class UserTest < ActiveSupport::TestCase
     assert user.valid?
   end
 
-  test "length of student_id" do
-    user = users(:bob)
-    assert user.valid?, "your student id must be 7 characters long"
-
-    user.student_id = 123456
-    assert user.invalid?, "your student id must be 7 characters long"
-  end
-
-
   test "no_waiver_users scope catches users that didn't read and agree to the waiver" do
     assert User.no_waiver_users.include? users(:sara)
     assert_equal(users(:sara).read_and_accepted_waiver_form, false)


### PR DESCRIPTION
New students have more than 7 character long student ids.