### PR TITLE
Remove rename Category

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -18,18 +18,18 @@ class Admin::SettingsController < AdminAreaController
     redirect_to admin_settings_path
   end
 
-  def rename_category
-    if !params[:category_option][:name].present?
-      flash[:alert] = "Invalid category name."
-    elsif params[:rename_category]==""
-      flash[:alert] = "Please select a category."
-    else
-      puts "params: #{params[:rename_category]}"
-      CategoryOption.where(:id => params[:rename_category]).update_all(cat_params)
-      flash[:notice] = "Category renamed successfully!"
-    end
-    redirect_to admin_settings_path
-  end
+  # def rename_category
+  #   if !params[:category_option][:name].present?
+  #     flash[:alert] = "Invalid category name."
+  #   elsif params[:rename_category]==""
+  #     flash[:alert] = "Please select a category."
+  #   else
+  #     puts "params: #{params[:rename_category]}"
+  #     CategoryOption.where(:id => params[:rename_category]).update_all(cat_params)
+  #     flash[:notice] = "Category renamed successfully!"
+  #   end
+  #   redirect_to admin_settings_path
+  # end
 
   def remove_category
     if params[:remove_category]!=""

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -16,13 +16,6 @@
       <%= select_tag :remove_category, options_from_collection_for_select(CategoryOption.show_options, :id, :name), class: "profile-select", include_blank: "Select a category..." %>
       <%= f.submit "Remove", class: 'save-button' %>
     <% end %>
-    <br>
-    <%= form_for @cat_option, url: {controller: "admin/settings", action: "rename_category"} do |f| %>
-      <%= f.label :rename_a_category, class: "profile-label" %>
-      <%= select_tag :rename_category, options_from_collection_for_select(CategoryOption.show_options, :id, :name), class: "profile-select", include_blank: "Select..." %>
-      <%= f.text_field :name, class: "profile-text", id:"rename_category_text" %>
-      <%= f.submit "Rename", class: 'save-button' %>
-    <% end %>
 
     <br><br><br>
     <div>Equipment options</div><hr><br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,7 +120,7 @@ Rails.application.routes.draw do
     resources :settings, only: [:index] do
       collection do
         post 'add_category'
-        post 'rename_category'
+        # post 'rename_category'
         post 'remove_category'
         post 'add_equipment'
         post 'rename_equipment'


### PR DESCRIPTION
Renaming a Category might create issues in sections of the website where category name is hard coded (ex. homepage categories)