### PR TITLE
no wrap of user names when hovered over

### DIFF
--- a/app/assets/stylesheets/admin/training_sessions.scss
+++ b/app/assets/stylesheets/admin/training_sessions.scss
@@ -134,6 +134,7 @@ div#sesh-users{
 div.users-count{
   cursor:pointer;
   padding: 40px 40px 40px 40px;
+  white-space: nowrap;
 }
 
 div.users-count:hover div#sesh-users{


### PR DESCRIPTION
when u hover over the training sessions' users, the names go to the next line. 
This small change should fix it.