### PR TITLE
fix program dropdown search box glitch

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -21,8 +21,3 @@ function showWaiver(toShow, toHide){
 	document.getElementById(toShow).style.display = 'block';
 	document.getElementById(toHide).style.display = 'none';
 }
-
-
-$(document).ready(function() {
-  $(".programs").select2({});
-});

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -306,3 +306,8 @@ l’Événement.
           <% end %>
 
 </section>
+<script>
+  $(document).ready(function() {
+    $(".programs").select2({});
+  });
+</script>


### PR DESCRIPTION
JS script doesn't seem to finish loading the first time link is clicked, so the select2 library is not loaded causing the search box not appearing. Moved the script directly below the html file.