### PR TITLE
Adding support for multiple RFID boxes per space

### DIFF
--- a/app/controllers/rfid_controller.rb
+++ b/app/controllers/rfid_controller.rb
@@ -47,10 +47,10 @@ class RfidController < SessionsController
 
   def check_session(rfid)
     active_sessions = rfid.user.lab_sessions.where('sign_out_time > ?', Time.zone.now)
-    new_location = PiReader.find_by(pi_mac_address: params[:mac_address])
+    new_location = PiReader.find_by(pi_mac_address: params[:mac_address]).space_id
     if active_sessions.present?
       active_sessions.update_all(sign_out_time: Time.zone.now)
-      last_active_location = PiReader.find_by(space_id: active_sessions.last.space.id)
+      last_active_location = active_sessions.last.space_id
       if last_active_location != new_location
         new_session(rfid, new_location)
       else
@@ -64,7 +64,7 @@ class RfidController < SessionsController
   def new_session(rfid, new_location)
     sign_in = Time.zone.now
     sign_out = sign_in + 6.hours
-    new_session = rfid.user.lab_sessions.new(sign_in_time: sign_in, sign_out_time: sign_out, mac_address: params[:mac_address], space_id: new_location.space.id)
+    new_session = rfid.user.lab_sessions.new(sign_in_time: sign_in, sign_out_time: sign_out, mac_address: params[:mac_address], space_id: new_location)
     new_session.save
     render json: { success: 'RFID sign in' }, status: :ok
   end

--- a/spec/controllers/rfid_controller_spec.rb
+++ b/spec/controllers/rfid_controller_spec.rb
@@ -39,6 +39,54 @@ RSpec.describe RfidController, type: :controller do
         expected = { error: 'Temporary RFID already exists' }
         expect(actual).to eq(expected)
       end
+
+      it 'should not create rfid and should sign in RFID and sign out' do
+        pi_reader = create(:pi_reader)
+        attributes = create(:rfid, mac_address: pi_reader.pi_mac_address)
+        rfid_params = { rfid: attributes.card_number, mac_address: attributes.mac_address }
+        expect { post :card_number, params: rfid_params, :format => :json }.to change(Rfid, :count).by(0)
+        actual = JSON.parse(response.body, symbolize_names: true)
+        expected = { success: 'RFID sign in' }
+        expect(actual).to eq(expected)
+        rfid_params = { rfid: attributes.card_number, mac_address: attributes.mac_address }
+        expect { post :card_number, params: rfid_params, :format => :json }.to change(Rfid, :count).by(0)
+        actual = JSON.parse(response.body, symbolize_names: true)
+        expected = { success: 'RFID sign out' }
+        expect(actual).to eq(expected)
+      end
+
+      it 'should not create rfid and should sign in RFID at one pi and sign out at other pi' do
+        sign_in_pi = create(:pi_reader)
+        sign_out_pi = create(:pi_reader, space_id: sign_in_pi.space_id)
+        attributes = create(:rfid, mac_address: sign_in_pi.pi_mac_address)
+        sign_in_rfid_params = { rfid: attributes.card_number, mac_address: sign_in_pi.pi_mac_address }
+        expect { post :card_number, params: sign_in_rfid_params, :format => :json }.to change(Rfid, :count).by(0)
+        actual = JSON.parse(response.body, symbolize_names: true)
+        sign_out_rfid_params = { rfid: attributes.card_number, mac_address: sign_out_pi.pi_mac_address }
+        expected = { success: 'RFID sign in' }
+        expect(actual).to eq(expected)
+        expect { post :card_number, params: sign_out_rfid_params, :format => :json }.to change(Rfid, :count).by(0)
+        actual = JSON.parse(response.body, symbolize_names: true)
+        expected = { success: 'RFID sign out' }
+        expect(actual).to eq(expected)
+      end
+
+      # #Temporary RFID Multi-box
+      # it 'should create an rfid and should sign in rfid ' do
+      #   sign_in_pi = create(:pi_reader)
+      #   sign_out_pi = create(:pi_reader, space_id: sign_in_pi.space_id)
+      #   attributes = FactoryBot.attributes_for(:rfid)
+      #   sign_in_rfid_params = { rfid: attributes[:card_number], mac_address: sign_in_pi.pi_mac_address }
+      #   expect { post :card_number, params: sign_in_rfid_params, :format => :json }.to change(Rfid, :count).by(1)
+      #   actual = JSON.parse(response.body, symbolize_names: true)
+      #   expected = { new_rfid: 'Temporary RFID created' }
+      #   expect(actual).to eq(expected)
+      #   sign_out_rfid_params = { rfid: attributes[:card_number], mac_address: sign_out_pi.pi_mac_address }
+      #   expect { post :card_number, params: sign_out_rfid_params, :format => :json }.to change(Rfid, :count).by(0)
+      #   actual = JSON.parse(response.body, symbolize_names: true)
+      #   expected = { error: 'Temporary RFID already exists' }
+      #   expect(actual).to eq(expected)
+      # end
     end
   end
 end

--- a/spec/controllers/rfid_controller_spec.rb
+++ b/spec/controllers/rfid_controller_spec.rb
@@ -71,22 +71,22 @@ RSpec.describe RfidController, type: :controller do
         expect(actual).to eq(expected)
       end
 
-      # #Temporary RFID Multi-box
-      # it 'should create an rfid and should sign in rfid ' do
-      #   sign_in_pi = create(:pi_reader)
-      #   sign_out_pi = create(:pi_reader, space_id: sign_in_pi.space_id)
-      #   attributes = FactoryBot.attributes_for(:rfid)
-      #   sign_in_rfid_params = { rfid: attributes[:card_number], mac_address: sign_in_pi.pi_mac_address }
-      #   expect { post :card_number, params: sign_in_rfid_params, :format => :json }.to change(Rfid, :count).by(1)
-      #   actual = JSON.parse(response.body, symbolize_names: true)
-      #   expected = { new_rfid: 'Temporary RFID created' }
-      #   expect(actual).to eq(expected)
-      #   sign_out_rfid_params = { rfid: attributes[:card_number], mac_address: sign_out_pi.pi_mac_address }
-      #   expect { post :card_number, params: sign_out_rfid_params, :format => :json }.to change(Rfid, :count).by(0)
-      #   actual = JSON.parse(response.body, symbolize_names: true)
-      #   expected = { error: 'Temporary RFID already exists' }
-      #   expect(actual).to eq(expected)
-      # end
+      #Temporary RFID Multi-box
+      it 'should create an rfid and should sign in rfid ' do
+        sign_in_pi = create(:pi_reader)
+        sign_out_pi = create(:pi_reader, space_id: sign_in_pi.space_id)
+        attributes = FactoryBot.attributes_for(:rfid)
+        sign_in_rfid_params = { rfid: attributes[:card_number], mac_address: sign_in_pi.pi_mac_address }
+        expect { post :card_number, params: sign_in_rfid_params, :format => :json }.to change(Rfid, :count).by(1)
+        actual = JSON.parse(response.body, symbolize_names: true)
+        expected = { new_rfid: 'Temporary RFID created' }
+        expect(actual).to eq(expected)
+        sign_out_rfid_params = { rfid: attributes[:card_number], mac_address: sign_out_pi.pi_mac_address }
+        expect { post :card_number, params: sign_out_rfid_params, :format => :json }.to change(Rfid, :count).by(0)
+        actual = JSON.parse(response.body, symbolize_names: true)
+        expected = { error: 'Temporary RFID already exists' }
+        expect(actual).to eq(expected)
+      end
     end
   end
 end


### PR DESCRIPTION
Change the sign in, sign out mechanism to lie on Space IDs instead of mac addresses. Added some unit testing as well, not sure if there is additional changes that need to be made to integrate it 