### PR TITLE
Adding error handling for FastImage exceptions

### DIFF
--- a/app/controllers/learning_area_controller.rb
+++ b/app/controllers/learning_area_controller.rb
@@ -87,7 +87,7 @@ class LearningAreaController < DevelopmentProgramsController
     def create_photos
       if params['images'].present?
         params['images'].each do |img|
-          dimension = FastImage.size(img.tempfile,:raise_on_failure=>true)
+          dimension = FastImage.size(img.tempfile,raise_on_failure: true)
           Photo.create(image: img, learning_module_id: @learning_module.id, width: dimension.first, height: dimension.last)
         end
       end
@@ -134,7 +134,7 @@ class LearningAreaController < DevelopmentProgramsController
 
       if params['images'].present?
         params['images'].each do |img|
-          dimension = FastImage.size(img.tempfile,:raise_on_failure=>true)
+          dimension = FastImage.size(img.tempfile,raise_on_failure: true)
           Photo.create(image: img, learning_module_id: @learning_module.id, width: dimension.first, height: dimension.last)
         end
       end

--- a/app/controllers/learning_area_controller.rb
+++ b/app/controllers/learning_area_controller.rb
@@ -25,10 +25,17 @@ class LearningAreaController < DevelopmentProgramsController
   def create
     @learning_module = LearningModule.new(learning_modules_params)
     if @learning_module.save
-      create_photos
-      create_files
-      flash[:notice] = 'Learning Module has been successfully created.'
-      render json: {redirect_uri: learning_area_path(@learning_module.id).to_s}
+      begin
+        create_photos
+      rescue FastImage::ImageFetchFailure, FastImage::UnknownImageType, FastImage::SizeNotFound => e
+        flash[:alert] = 'Something went wrong while uploading photos, try again later.'
+        @learning_module.destroy
+        render json: {redirect_uri: request.path}
+      else
+        create_files
+        flash[:notice] = 'Learning Module has been successfully created.'
+        render json: {redirect_uri: learning_area_path(@learning_module.id).to_s}
+      end
     else
       flash[:alert] = 'Something went wrong'
       render json: @learning_module.errors['title'].first, status: :unprocessable_entity
@@ -47,11 +54,17 @@ class LearningAreaController < DevelopmentProgramsController
 
   def update
     if @learning_module.update(learning_modules_params)
-      update_photos
       update_files
       update_videos
-      flash[:notice] = 'Learning module successfully updated.'
-      render json: {redirect_uri: learning_area_path(@learning_module.id).to_s}
+      begin
+        update_photos
+      rescue FastImage::ImageFetchFailure, FastImage::UnknownImageType, FastImage::SizeNotFound => e
+        flash[:alert_yellow] = 'Something went wrong while uploading photos, try again later. Other changes have been saved.'
+        render json: {redirect_uri: learning_area_path(@learning_module.id).to_s}
+      else
+        flash[:notice] = 'Learning module successfully updated.'
+        render json: {redirect_uri: learning_area_path(@learning_module.id).to_s}
+      end
     else
       flash[:alert] = 'Unable to apply the changes.'
       render json: @learning_module.errors['title'].first, status: :unprocessable_entity
@@ -74,7 +87,7 @@ class LearningAreaController < DevelopmentProgramsController
     def create_photos
       if params['images'].present?
         params['images'].each do |img|
-          dimension = FastImage.size(img.tempfile)
+          dimension = FastImage.size("img.tempfile",:raise_on_failure=>true)
           Photo.create(image: img, learning_module_id: @learning_module.id, width: dimension.first, height: dimension.last)
         end
       end
@@ -121,7 +134,7 @@ class LearningAreaController < DevelopmentProgramsController
 
       if params['images'].present?
         params['images'].each do |img|
-          dimension = FastImage.size(img.tempfile)
+          dimension = FastImage.size("img.tempfile",:raise_on_failure=>true)
           Photo.create(image: img, learning_module_id: @learning_module.id, width: dimension.first, height: dimension.last)
         end
       end

--- a/app/controllers/learning_area_controller.rb
+++ b/app/controllers/learning_area_controller.rb
@@ -87,7 +87,7 @@ class LearningAreaController < DevelopmentProgramsController
     def create_photos
       if params['images'].present?
         params['images'].each do |img|
-          dimension = FastImage.size("img.tempfile",:raise_on_failure=>true)
+          dimension = FastImage.size(img.tempfile,:raise_on_failure=>true)
           Photo.create(image: img, learning_module_id: @learning_module.id, width: dimension.first, height: dimension.last)
         end
       end
@@ -134,7 +134,7 @@ class LearningAreaController < DevelopmentProgramsController
 
       if params['images'].present?
         params['images'].each do |img|
-          dimension = FastImage.size("img.tempfile",:raise_on_failure=>true)
+          dimension = FastImage.size(img.tempfile,:raise_on_failure=>true)
           Photo.create(image: img, learning_module_id: @learning_module.id, width: dimension.first, height: dimension.last)
         end
       end

--- a/app/controllers/makes_controller.rb
+++ b/app/controllers/makes_controller.rb
@@ -50,7 +50,7 @@ class MakesController < SessionsController
   def create_photos
     if params[:images].present?
       params[:images].each do |img|
-        dimension = FastImage.size(img.tempfile,:raise_on_failure=>true)
+        dimension = FastImage.size(img.tempfile,raise_on_failure: true)
         Photo.create(image: img, repository_id: @repo.id, width: dimension.first, height: dimension.last)
       end
       end

--- a/app/controllers/makes_controller.rb
+++ b/app/controllers/makes_controller.rb
@@ -50,7 +50,7 @@ class MakesController < SessionsController
   def create_photos
     if params[:images].present?
       params[:images].each do |img|
-        dimension = FastImage.size("img.tempfile",:raise_on_failure=>true)
+        dimension = FastImage.size(img.tempfile,:raise_on_failure=>true)
         Photo.create(image: img, repository_id: @repo.id, width: dimension.first, height: dimension.last)
       end
       end

--- a/app/controllers/makes_controller.rb
+++ b/app/controllers/makes_controller.rb
@@ -18,14 +18,22 @@ class MakesController < SessionsController
     end
 
     if @repo.save
-      @repo.update(slug: @repo.id.to_s + '.' + @repo.title.downcase.gsub(/[^0-9a-z ]/i, '').gsub(/\s+/, '-'))
-      create_photos
-      copy_categories_and_equipment
-      @repository.increment!(:make)
-      render json: { redirect_uri: repository_path(@user.username, @repo.slug).to_s }
-      @user.increment!(:reputation, 15)
+      begin
+        create_photos
+      rescue FastImage::ImageFetchFailure, FastImage::UnknownImageType, FastImage::SizeNotFound => e  
+        flash[:alert] = 'Something went wrong while uploading photos, but the make was created. Try uploading them again later.'
+        @repo.destroy
+        render json: {redirect_uri: request.path}
+      else
+        @repo.update(slug: @repo.id.to_s + '.' + @repo.title.downcase.gsub(/[^0-9a-z ]/i, '').gsub(/\s+/, '-'))
+        copy_categories_and_equipment
+        @repository.increment!(:make)
+        render json: { redirect_uri: repository_path(@user.username, @repo.slug).to_s }
+        @user.increment!(:reputation, 15)
+      end
     else
-      render :new, alert: 'Something went wrong'
+      flash[:alert] = 'Something went wrong'
+      render json: @repo.errors['title'].first, status: :unprocessable_entity
     end
   end
 
@@ -42,7 +50,7 @@ class MakesController < SessionsController
   def create_photos
     if params[:images].present?
       params[:images].each do |img|
-        dimension = FastImage.size(img.tempfile)
+        dimension = FastImage.size("img.tempfile",:raise_on_failure=>true)
         Photo.create(image: img, repository_id: @repo.id, width: dimension.first, height: dimension.last)
       end
       end

--- a/app/controllers/proficient_projects_controller.rb
+++ b/app/controllers/proficient_projects_controller.rb
@@ -215,7 +215,7 @@ class ProficientProjectsController < DevelopmentProgramsController
   def create_photos
     if params['images'].present?
       params['images'].each do |img|
-        dimension = FastImage.size("img.tempfile",:raise_on_failure=>true)
+        dimension = FastImage.size(img.tempfile,:raise_on_failure=>true)
         Photo.create(image: img, proficient_project_id: @proficient_project.id, width: dimension.first, height: dimension.last)
       end
     end
@@ -258,7 +258,7 @@ class ProficientProjectsController < DevelopmentProgramsController
 
     if params['images'].present?
       params['images'].each do |img|
-        dimension = FastImage.size("img.tempfile",:raise_on_failure=>true)
+        dimension = FastImage.size(img.tempfile,:raise_on_failure=>true)
         Photo.create(image: img, proficient_project_id: @proficient_project.id, width: dimension.first, height: dimension.last)
       end
     end

--- a/app/controllers/proficient_projects_controller.rb
+++ b/app/controllers/proficient_projects_controller.rb
@@ -215,7 +215,7 @@ class ProficientProjectsController < DevelopmentProgramsController
   def create_photos
     if params['images'].present?
       params['images'].each do |img|
-        dimension = FastImage.size(img.tempfile,:raise_on_failure=>true)
+        dimension = FastImage.size(img.tempfile,raise_on_failure: true)
         Photo.create(image: img, proficient_project_id: @proficient_project.id, width: dimension.first, height: dimension.last)
       end
     end
@@ -258,7 +258,7 @@ class ProficientProjectsController < DevelopmentProgramsController
 
     if params['images'].present?
       params['images'].each do |img|
-        dimension = FastImage.size(img.tempfile,:raise_on_failure=>true)
+        dimension = FastImage.size(img.tempfile,raise_on_failure: true)
         Photo.create(image: img, proficient_project_id: @proficient_project.id, width: dimension.first, height: dimension.last)
       end
     end

--- a/app/controllers/project_proposals_controller.rb
+++ b/app/controllers/project_proposals_controller.rb
@@ -231,7 +231,7 @@ class ProjectProposalsController < ApplicationController
   def create_photos
     if params[:images].present?
       params[:images].first(5).each do |img|
-        dimension = FastImage.size("img.tempfile",:raise_on_failure=>true)
+        dimension = FastImage.size(img.tempfile,:raise_on_failure=>true)
         Photo.create(image: img, project_proposal_id: @project_proposal.id, width: dimension.first, height: dimension.last)
       end
     end
@@ -257,7 +257,7 @@ class ProjectProposalsController < ApplicationController
 
     if params['images'].present?
       params['images'].each do |img|
-        dimension = FastImage.size("img.tempfile",:raise_on_failure=>true)
+        dimension = FastImage.size(img.tempfile,:raise_on_failure=>true)
         Photo.create(image: img, project_proposal_id: @project_proposal.id, width: dimension.first, height: dimension.last)
       end
     end

--- a/app/controllers/project_proposals_controller.rb
+++ b/app/controllers/project_proposals_controller.rb
@@ -231,7 +231,7 @@ class ProjectProposalsController < ApplicationController
   def create_photos
     if params[:images].present?
       params[:images].first(5).each do |img|
-        dimension = FastImage.size(img.tempfile,:raise_on_failure=>true)
+        dimension = FastImage.size(img.tempfile,raise_on_failure: true)
         Photo.create(image: img, project_proposal_id: @project_proposal.id, width: dimension.first, height: dimension.last)
       end
     end
@@ -257,7 +257,7 @@ class ProjectProposalsController < ApplicationController
 
     if params['images'].present?
       params['images'].each do |img|
-        dimension = FastImage.size(img.tempfile,:raise_on_failure=>true)
+        dimension = FastImage.size(img.tempfile,raise_on_failure: true)
         Photo.create(image: img, project_proposal_id: @project_proposal.id, width: dimension.first, height: dimension.last)
       end
     end

--- a/app/controllers/project_proposals_controller.rb
+++ b/app/controllers/project_proposals_controller.rb
@@ -70,13 +70,23 @@ class ProjectProposalsController < ApplicationController
 
     respond_to do |format|
       if verify_recaptcha(model: @project_proposal) && @project_proposal.save
-        create_photos
-        create_files
-        create_categories
-        @project_proposal.save # This creates the slug with ID since the ID is not created before create
-        format.html { redirect_to project_proposal_path(@project_proposal.slug), notice: 'Project proposal was successfully created.' }
-        format.json { render json: { redirect_uri: project_proposal_path(@project_proposal.slug).to_s } }
-        MsrMailer.send_new_project_proposals.deliver_now
+        begin
+          create_photos
+        rescue FastImage::ImageFetchFailure, FastImage::UnknownImageType, FastImage::SizeNotFound => e
+          Airbrake.notify(e)
+          flash[:alert] = 'Something went wrong while uploading photos, try again later.'
+          @project_proposal.destroy
+          format.json {render json: {redirect_uri: request.path}}
+          format.html {redirect_back fallback_location: request.path}
+
+        else
+          create_files
+          create_categories
+          @project_proposal.save # This creates the slug with ID since the ID is not created before create
+          format.html { redirect_to project_proposal_path(@project_proposal.slug), notice: 'Project proposal was successfully created.' }
+          format.json { render json: { redirect_uri: project_proposal_path(@project_proposal.slug).to_s } }
+          MsrMailer.send_new_project_proposals.deliver_now
+        end
       else
         flash[:alert] = 'An error occurred while creating the project proposal, try again later.'
         format.html { render :new, status: :unprocessable_entity }
@@ -146,11 +156,19 @@ class ProjectProposalsController < ApplicationController
     @project_proposal.categories.destroy_all
     respond_to do |format|
       if @project_proposal.update(project_proposal_params)
-        update_photos
         update_files
         create_categories
-        format.html { redirect_to project_proposal_path(@project_proposal.slug), notice: 'Project proposal was successfully updated.' }
-        format.json { render json: { redirect_uri: project_proposal_path(@project_proposal.slug).to_s } }
+        begin 
+          update_photos
+        rescue FastImage::ImageFetchFailure, FastImage::UnknownImageType, FastImage::SizeNotFound => e
+          Airbrake.notify(e)
+          flash[:alert_yellow] = 'Something went wrong while uploading photos, try again later. Other changes have been saved. '
+          format.json {render json: {redirect_uri: request.path}}
+          format.html {redirect_back fallback_location: request.path}
+        else
+          format.html { redirect_to project_proposal_path(@project_proposal.slug), notice: 'Project proposal was successfully updated.' }
+          format.json { render json: { redirect_uri: project_proposal_path(@project_proposal.slug).to_s } }
+        end
       else
         flash[:alert] = 'An error occurred while updating the project proposal, try again later.'
         format.html { render :edit, status: :unprocessable_entity }
@@ -213,7 +231,7 @@ class ProjectProposalsController < ApplicationController
   def create_photos
     if params[:images].present?
       params[:images].first(5).each do |img|
-        dimension = FastImage.size(img.tempfile)
+        dimension = FastImage.size("img.tempfile",:raise_on_failure=>true)
         Photo.create(image: img, project_proposal_id: @project_proposal.id, width: dimension.first, height: dimension.last)
       end
     end
@@ -239,7 +257,7 @@ class ProjectProposalsController < ApplicationController
 
     if params['images'].present?
       params['images'].each do |img|
-        dimension = FastImage.size(img.tempfile)
+        dimension = FastImage.size("img.tempfile",:raise_on_failure=>true)
         Photo.create(image: img, project_proposal_id: @project_proposal.id, width: dimension.first, height: dimension.last)
       end
     end

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -250,7 +250,7 @@ class RepositoriesController < SessionsController
   def create_photos
     if params[:images].present?
       params[:images].first(5).each do |img|
-        dimension = FastImage.size("img.tempfile",:raise_on_failure=>true)
+        dimension = FastImage.size(img.tempfile,:raise_on_failure=>true)
         Photo.create(image: img, repository_id: @repository.id, width: dimension.first, height: dimension.last)
       end
     end
@@ -276,7 +276,7 @@ class RepositoriesController < SessionsController
 
     if params['images'].present?
       params['images'].each do |img|
-        dimension = FastImage.size("img.tempfile",:raise_on_failure=>true)
+        dimension = FastImage.size(img.tempfile,:raise_on_failure=>true)
         Photo.create(image: img, repository_id: @repository.id, width: dimension.first, height: dimension.last)
       end
     end

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -250,7 +250,7 @@ class RepositoriesController < SessionsController
   def create_photos
     if params[:images].present?
       params[:images].first(5).each do |img|
-        dimension = FastImage.size(img.tempfile,:raise_on_failure=>true)
+        dimension = FastImage.size(img.tempfile,raise_on_failure: true)
         Photo.create(image: img, repository_id: @repository.id, width: dimension.first, height: dimension.last)
       end
     end
@@ -276,7 +276,7 @@ class RepositoriesController < SessionsController
 
     if params['images'].present?
       params['images'].each do |img|
-        dimension = FastImage.size(img.tempfile,:raise_on_failure=>true)
+        dimension = FastImage.size(img.tempfile,raise_on_failure: true)
         Photo.create(image: img, repository_id: @repository.id, width: dimension.first, height: dimension.last)
       end
     end


### PR DESCRIPTION
Two different styles of error handling, for creates we don't create the object and redirect the user back, for updates we update as much as we can in case they have changed content, descriptions, files, etc and throw a warning. 