### PR TITLE
Fix for header background in collapses

### DIFF
--- a/app/javascript/packs/header.js
+++ b/app/javascript/packs/header.js
@@ -59,15 +59,19 @@ document.addEventListener("turbolinks:load", function () {
       !nav.classList.contains("static_pages") &&
       !nav.classList.contains("home")
     ) {
+      console.log("1");
       doTransition(false, false);
     } else if (
       navbarSupportedContent.clientHeight > 0 &&
       window.matchMedia("(max-width: 1200px)").matches
     ) {
+      console.log("2");
       doTransition(false, false);
     } else if (document.getElementById("flash").clientHeight > 0) {
+      console.log("3");
       doTransition(false, false);
     } else {
+      console.log("4");
       doTransition(true, false);
     }
   }
@@ -106,8 +110,10 @@ document.addEventListener("turbolinks:load", function () {
   });
 
   navToggler.addEventListener("click", () => {
-    if (navbarSupportedContent.clientHeight != 0) {
-      doTransition(false, false);
+    if (navbarSupportedContent.clientHeight == 0) {
+      window.matchMedia("(max-width: 1200px").matches
+        ? doTransition(false, false)
+        : doTransition(true, false);
     } else {
       window.scrollY < 10
         ? doTransition(true, false)
@@ -133,4 +139,5 @@ document.addEventListener("turbolinks:load", function () {
   flashObserver.observe(document.getElementById("flash"));
 
   check();
+  console.log("11");
 });

--- a/app/javascript/packs/header.js
+++ b/app/javascript/packs/header.js
@@ -17,10 +17,12 @@ document.addEventListener("turbolinks:load", function () {
   var navbarSupportedContent = document.getElementById(
     "navbarSupportedContent"
   );
+  var navExpanded = navToggler.classList.contains("collapsed");
   var chevron = document.getElementsByClassName("down-indicator")[0];
   var cc_image_white = document.getElementById("myCcWhite");
   var cc_image_black = document.getElementById("myCcBlack");
   function doTransition(dark, animate) {
+    state = !dark;
     if (
       !(
         nav.classList.contains("static_pages") && nav.classList.contains("home")
@@ -59,19 +61,15 @@ document.addEventListener("turbolinks:load", function () {
       !nav.classList.contains("static_pages") &&
       !nav.classList.contains("home")
     ) {
-      console.log("1");
       doTransition(false, false);
     } else if (
       navbarSupportedContent.clientHeight > 0 &&
       window.matchMedia("(max-width: 1200px)").matches
     ) {
-      console.log("2");
       doTransition(false, false);
     } else if (document.getElementById("flash").clientHeight > 0) {
-      console.log("3");
       doTransition(false, false);
     } else {
-      console.log("4");
       doTransition(true, false);
     }
   }
@@ -110,15 +108,8 @@ document.addEventListener("turbolinks:load", function () {
   });
 
   navToggler.addEventListener("click", () => {
-    if (navbarSupportedContent.clientHeight == 0) {
-      window.matchMedia("(max-width: 1200px").matches
-        ? doTransition(false, false)
-        : doTransition(true, false);
-    } else {
-      window.scrollY < 10
-        ? doTransition(true, false)
-        : doTransition(false, false);
-    }
+    navExpanded = !navToggler.classList.contains("collapsed");
+    doTransition(!navExpanded, navExpanded);
   });
 
   window.addEventListener("resize", () => {
@@ -139,5 +130,4 @@ document.addEventListener("turbolinks:load", function () {
   flashObserver.observe(document.getElementById("flash"));
 
   check();
-  console.log("11");
 });

--- a/app/javascript/packs/header.js
+++ b/app/javascript/packs/header.js
@@ -17,7 +17,7 @@ document.addEventListener("turbolinks:load", function () {
   var navbarSupportedContent = document.getElementById(
     "navbarSupportedContent"
   );
-  var navExpanded = navToggler.classList.contains("collapsed");
+  var isCollapsed = navToggler.classList.contains("collapsed");
   var chevron = document.getElementsByClassName("down-indicator")[0];
   var cc_image_white = document.getElementById("myCcWhite");
   var cc_image_black = document.getElementById("myCcBlack");
@@ -108,15 +108,12 @@ document.addEventListener("turbolinks:load", function () {
   });
 
   navToggler.addEventListener("click", () => {
-    navExpanded = !navToggler.classList.contains("collapsed");
-    doTransition(!navExpanded, navExpanded);
+    isCollapsed = !navToggler.classList.contains("collapsed");
+    doTransition(!isCollapsed, isCollapsed);
   });
 
   window.addEventListener("resize", () => {
-    if (
-      window.matchMedia("(max-width: 1200px)").matches &&
-      navbarSupportedContent.clientHeight > 0
-    ) {
+    if (window.matchMedia("(max-width: 1200px)").matches && isCollapsed) {
       doTransition(false, false);
       return;
     }


### PR DESCRIPTION
On mobile the transitions were inverted, opening the collapsed header would set the BG to transparent, and closing it would set it to light 