### PR TITLE
Proposed project search includes all projects.

### DIFF
--- a/app/controllers/project_proposals_controller.rb
+++ b/app/controllers/project_proposals_controller.rb
@@ -11,46 +11,34 @@ class ProjectProposalsController < ApplicationController
     if params[:search].blank?
       @pending_project_proposals =
         ProjectProposal
-          .all
-          .joins(:user)
           .order(created_at: :desc)
           .where(approved: nil)
           .paginate(per_page: 15, page: params[:page_pending])
       @approved_project_proposals =
         ProjectProposal
-          .all
-          .joins(:user)
           .order(created_at: :desc)
           .where(approved: 1)
           .paginate(per_page: 15, page: params[:page_approved])
       @not_approved_project_proposals =
         ProjectProposal
-          .all
-          .joins(:user)
           .order(created_at: :desc)
           .where(approved: 0)
           .paginate(per_page: 15, page: params[:page_not_approved])
     else
       @pending_project_proposals =
         ProjectProposal
-          .all
-          .joins(:user)
           .filter_by_attribute(params[:search])
           .order(created_at: :desc)
           .where(approved: nil)
           .paginate(per_page: 15, page: params[:page_pending])
       @approved_project_proposals =
         ProjectProposal
-          .all
-          .joins(:user)
           .filter_by_attribute(params[:search])
           .order(created_at: :desc)
           .where(approved: 1)
           .paginate(per_page: 15, page: params[:page_approved])
       @not_approved_project_proposals =
         ProjectProposal
-          .all
-          .joins(:user)
           .filter_by_attribute(params[:search])
           .order(created_at: :desc)
           .where(approved: 0)


### PR DESCRIPTION
Removes the joins user clause of our queries to show all project proposals on the search page