### PR TITLE
Fixing repo editing issue

### DIFF
--- a/app/views/repositories/edit.html.erb
+++ b/app/views/repositories/edit.html.erb
@@ -109,7 +109,7 @@
     <br>
     <br>
     <br>
-    <% tag 'repository[id]', @repository.id %>
+    <%= tag('repository[id]', content: @repository.id, type: 'hidden') %>
     <%= f.submit 'Update Project', class: 'btn btn-primary', id: 'waiting-save-button' %>
     <span id="status-save"></span>
     <br>


### PR DESCRIPTION
Linter changed content_tag to tag, which isn't a drop in replacement