### PR TITLE
Fix/repository photo gallery

### DIFF
--- a/app/javascript/entrypoints/application.scss
+++ b/app/javascript/entrypoints/application.scss
@@ -1,4 +1,4 @@
-$pswp__assets-path: "~photoswipe/src/css/default-skin/";
+$pswp__assets-path: "photoswipe/src/css/default-skin/";
 
 @import "shared/variables";
 @import "photoswipe/src/css/main";

--- a/app/javascript/entrypoints/photo_gallery.js
+++ b/app/javascript/entrypoints/photo_gallery.js
@@ -5,33 +5,39 @@ document.addEventListener("DOMContentLoaded", function () {
   var images = [];
 
   var parseImages = function (el) {
-    var childNodes = el.children;
-    var items = [];
+    if (el) {
+      var childNodes = el.children;
+      var items = [];
 
-    Array.from(childNodes).forEach(function (node, index) {
-      if (node.tagName === "IMG") {
-        let item = {
-          src: node.src,
-          w: node.getAttribute("data-width"),
-          h: node.getAttribute("data-height"),
-        };
-        items.push(item);
-
-        node.addEventListener("click", () => openPhotoSwipe(index));
+      if (childNodes === undefined) {
+        return;
       }
-    });
 
-    images = items;
+      Array.from(childNodes).forEach(function (node, index) {
+        if (node.tagName === "IMG") {
+          let item = {
+            src: node.src,
+            w: node.getAttribute("data-width"),
+            h: node.getAttribute("data-height"),
+          };
+          items.push(item);
 
-    var mainImageDiv = document.getElementById("show-photo");
-    if (
-      mainImageDiv &&
-      mainImageDiv.children[0] &&
-      mainImageDiv.children[0].tagName === "IMG"
-    ) {
-      mainImageDiv.children[0].addEventListener("click", () =>
-        openPhotoSwipe(0)
-      );
+          node.addEventListener("click", () => openPhotoSwipe(index));
+        }
+      });
+
+      images = items;
+
+      var mainImageDiv = document.getElementById("show-photo");
+      if (
+        mainImageDiv &&
+        mainImageDiv.children[0] &&
+        mainImageDiv.children[0].tagName === "IMG"
+      ) {
+        mainImageDiv.children[0].addEventListener("click", () =>
+          openPhotoSwipe(0)
+        );
+      }
     }
   };
 

--- a/app/javascript/entrypoints/photo_gallery.js
+++ b/app/javascript/entrypoints/photo_gallery.js
@@ -3,6 +3,7 @@ import PhotoSwipeUI_Default from "photoswipe/dist/photoswipe-ui-default";
 
 document.addEventListener("DOMContentLoaded", function () {
   var images = [];
+  var image_tags = [];
 
   var parseImages = function (el) {
     if (el) {
@@ -21,6 +22,7 @@ document.addEventListener("DOMContentLoaded", function () {
             h: node.getAttribute("data-height"),
           };
           items.push(item);
+          image_tags.push(node);
 
           node.addEventListener("click", () => openPhotoSwipe(index));
         }
@@ -44,6 +46,20 @@ document.addEventListener("DOMContentLoaded", function () {
   var openPhotoSwipe = function (startIndex) {
     var options = {
       index: startIndex,
+      getThumbBoundsFn: function (index) {
+        var currentImage = image_tags[index];
+        var pageYScroll = window.scrollY || document.documentElement.scrollTop;
+        var boundingRect = currentImage.getBoundingClientRect();
+
+        var rect = {
+          x: boundingRect.left,
+          y: boundingRect.top + pageYScroll,
+          w: boundingRect.width,
+        };
+
+        return rect;
+      },
+      bgOpacity: 0.7,
     };
 
     var gallery = new PhotoSwipe(
@@ -52,6 +68,7 @@ document.addEventListener("DOMContentLoaded", function () {
       images,
       options
     );
+
     gallery.init();
   };
 

--- a/app/javascript/entrypoints/photo_gallery.js
+++ b/app/javascript/entrypoints/photo_gallery.js
@@ -2,13 +2,15 @@ import PhotoSwipe from "photoswipe";
 import PhotoSwipeUI_Default from "photoswipe/dist/photoswipe-ui-default";
 
 document.addEventListener("DOMContentLoaded", function () {
-  var images = [];
-  var image_tags = [];
+  const pswpElement = document.querySelectorAll(".pswp")[0];
+  const imageGallery = document.getElementById("photo-slide");
+  let images = [];
+  let image_tags = [];
 
-  var parseImages = function (el) {
+  const parseImages = function (el) {
     if (el) {
-      var childNodes = el.children;
-      var items = [];
+      const childNodes = el.children;
+      let items = [];
 
       if (childNodes === undefined) {
         return;
@@ -16,7 +18,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
       Array.from(childNodes).forEach(function (node, index) {
         if (node.tagName === "IMG") {
-          let item = {
+          const item = {
             src: node.src,
             w: node.getAttribute("data-width"),
             h: node.getAttribute("data-height"),
@@ -30,7 +32,8 @@ document.addEventListener("DOMContentLoaded", function () {
 
       images = items;
 
-      var mainImageDiv = document.getElementById("show-photo");
+      const mainImageDiv = document.getElementById("show-photo");
+
       if (
         mainImageDiv &&
         mainImageDiv.children[0] &&
@@ -43,15 +46,16 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   };
 
-  var openPhotoSwipe = function (startIndex) {
-    var options = {
+  const openPhotoSwipe = function (startIndex) {
+    const options = {
       index: startIndex,
       getThumbBoundsFn: function (index) {
-        var currentImage = image_tags[index];
-        var pageYScroll = window.scrollY || document.documentElement.scrollTop;
-        var boundingRect = currentImage.getBoundingClientRect();
+        const currentImage = image_tags[index];
+        const pageYScroll =
+          window.scrollY || document.documentElement.scrollTop;
+        const boundingRect = currentImage.getBoundingClientRect();
 
-        var rect = {
+        const rect = {
           x: boundingRect.left,
           y: boundingRect.top + pageYScroll,
           w: boundingRect.width,
@@ -62,7 +66,7 @@ document.addEventListener("DOMContentLoaded", function () {
       bgOpacity: 0.7,
     };
 
-    var gallery = new PhotoSwipe(
+    let gallery = new PhotoSwipe(
       pswpElement,
       PhotoSwipeUI_Default,
       images,
@@ -72,6 +76,5 @@ document.addEventListener("DOMContentLoaded", function () {
     gallery.init();
   };
 
-  parseImages(document.getElementById("photo-slide"));
-  var pswpElement = document.querySelectorAll(".pswp")[0];
+  parseImages(imageGallery);
 });

--- a/app/javascript/entrypoints/photo_gallery.js
+++ b/app/javascript/entrypoints/photo_gallery.js
@@ -1,45 +1,54 @@
-// var photoArray = [];
-//
-// document.addEventListener("DOMContentLoaded", function () {
-//   photoArray = [];
-//   let gallery = photoSwipe();
-//   let photoSlide = document.getElementById("photo-slide");
-//   if (photoSlide) {
-//     photoSlide.childNodes.forEach(function (node) {
-//       let img = node;
-//       if (img.tagName === "IMG") {
-//         photoArray.push({
-//           src: img.getAttribute("src"),
-//           w: img.getAttribute("data-width"),
-//           h: img.getAttribute("data-height"),
-//         });
-//         img.addEventListener("click", function () {
-//           gallery.init();
-//         });
-//       }
-//     });
-//   }
-//   let showPhoto = document.getElementById("show-photo");
-//   if (showPhoto) {
-//     showPhoto.addEventListener("click", function () {
-//       gallery.init();
-//     });
-//   }
-// });
-//
-// function photoSwipe() {
-//   var pswpElement = document.querySelectorAll(".pswp")[0];
-//
-//   var items = photoArray;
-//   var options = {
-//     index: 0,
-//   };
-//
-//   var gallery = new PhotoSwipe(
-//     pswpElement,
-//     PhotoSwipeUI_Default,
-//     items,
-//     options
-//   );
-//   return gallery;
-// }
+import PhotoSwipe from "photoswipe";
+import PhotoSwipeUI_Default from "photoswipe/dist/photoswipe-ui-default";
+
+document.addEventListener("DOMContentLoaded", function () {
+  var images = [];
+
+  var parseImages = function (el) {
+    var childNodes = el.children;
+    var items = [];
+
+    Array.from(childNodes).forEach(function (node, index) {
+      if (node.tagName === "IMG") {
+        let item = {
+          src: node.src,
+          w: node.getAttribute("data-width"),
+          h: node.getAttribute("data-height"),
+        };
+        items.push(item);
+
+        node.addEventListener("click", () => openPhotoSwipe(index));
+      }
+    });
+
+    images = items;
+
+    var mainImageDiv = document.getElementById("show-photo");
+    if (
+      mainImageDiv &&
+      mainImageDiv.children[0] &&
+      mainImageDiv.children[0].tagName === "IMG"
+    ) {
+      mainImageDiv.children[0].addEventListener("click", () =>
+        openPhotoSwipe(0)
+      );
+    }
+  };
+
+  var openPhotoSwipe = function (startIndex) {
+    var options = {
+      index: startIndex,
+    };
+
+    var gallery = new PhotoSwipe(
+      pswpElement,
+      PhotoSwipeUI_Default,
+      images,
+      options
+    );
+    gallery.init();
+  };
+
+  parseImages(document.getElementById("photo-slide"));
+  var pswpElement = document.querySelectorAll(".pswp")[0];
+});


### PR DESCRIPTION
## Summary
Fixed not being able to open photos in the show views for repositories, project proposals, learning modules, and proficiency projects by implementing [PhotoSwipe](https://www.npmjs.com/package/photoswipe) v4.1.3 in the MakerRepo app. Users can now click on images and open a photo gallery of related images. Photo galleries have UI elements that allow users to move between photos, zoom in/out, share photos, and go fullscreen.

## Preview
![Screenshot 2023-05-11 at 4 36 31 PM](https://github.com/uOttawa-Makerspace/MakerSpaceRepo/assets/75919484/eeeb196a-ab5f-4afc-acb1-76fb461085cd)

