### PR TITLE
Fix/private repo password

### DIFF
--- a/app/assets/stylesheets/password_entry.scss
+++ b/app/assets/stylesheets/password_entry.scss
@@ -2,7 +2,6 @@
 
 section#password_entry {
   @include outer-container(60rem);
-  height: 16rem;
   background-color: #fff;
   padding: 4rem 5rem 8rem;
 
@@ -11,7 +10,7 @@ section#password_entry {
     color: red;
     display: block;
     font: 300 2rem "Raleway", helvetica, sans-serif;
-    font-size: 30px;
+    font-size: 27px;
     // padding: 2rem 0;
     // max-width: 80%;
     // margin: auto;
@@ -19,13 +18,8 @@ section#password_entry {
 
   input:not([type="checkbox"]) {
     display: block;
-    padding: 0.5rem;
-    height: 30px;
-    width: 400px;
-    border: 1px solid #aaa;
     margin: 0 auto;
     font: 400 1.09rem "Raleway", helvetica, sans-serif;
-    border-bottom: none;
 
     // &:nth-last-child(3){
     //   border-top-left-radius: 3px;
@@ -38,13 +32,6 @@ div.title#password_entry {
   text-align: center;
 }
 input.login-button {
-  width: calc(400px + 1.09rem) !important;
-  height: calc(30px + 1.09rem) !important;
-  letter-spacing: 1px;
-  background-color: #4bbc9c;
-  color: #fff;
-  border: none !important;
-
   &:hover {
     cursor: pointer;
   }

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -229,7 +229,7 @@ class RepositoriesController < SessionsController
         format.html do
           redirect_to password_entry_repository_path(
                         @repository.user_username,
-                        @repository.slug
+                        @repository.id
                       )
         end
       end

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -12,6 +12,7 @@ class RepositoriesController < SessionsController
                   download_files
                   check_auth
                   pass_authenticate
+                  password_entry
                 ]
   before_action :check_auth, only: [:show]
 
@@ -208,6 +209,9 @@ class RepositoriesController < SessionsController
   end
 
   def password_entry
+    if !@repository.private?
+      redirect_to repository_path(@repository.user_username, @repository.id)
+    end
   end
 
   def pass_authenticate

--- a/app/views/repositories/password_entry.html.erb
+++ b/app/views/repositories/password_entry.html.erb
@@ -4,7 +4,7 @@
   </div>
   <%= form_tag pass_authenticate_repository_path do %>
 
-    <%= password_field_tag :password, nil, placeholder: 'Password' %>
+    <%= password_field_tag :password, nil, placeholder: 'Password', class: 'mb-3' %>
 
     <%= submit_tag 'Sign In/Connexion', class: 'login-button', 'tab-index': '3' %>
 

--- a/app/views/repositories/password_entry.html.erb
+++ b/app/views/repositories/password_entry.html.erb
@@ -1,15 +1,15 @@
-<section id= "password_entry">
-  <div class= "title" id="pass_entry">
-    <p> This project is private<br>Please enter password to access the page </p>
-  </div>
-  <%= form_tag pass_authenticate_repository_path do %>
-
-    <%= password_field_tag :password, nil, placeholder: 'Password', class: 'mb-3' %>
-
-    <%= submit_tag 'Sign In/Connexion', class: 'login-button', 'tab-index': '3' %>
-
-  <% end %>
-
-</section>
-
-<br>
+<div class="container">
+  <section class="card mt-4">
+    <div class="col-lg-7 mx-auto">
+      <section id="password_entry">
+        <div class= "title" id="pass_entry">
+          <p> This project is private<br>Ce projet est privé</p>
+        </div>
+        <%= form_tag pass_authenticate_repository_path do %>
+          <%= password_field_tag :password, nil, placeholder: 'Password/Mot de passe', class: 'mb-4 form-control' %>
+          <%= submit_tag 'View Page/Voir la page', class: 'login-button btn btn-success p-3', 'tab-index': '3' %>
+        <% end %>
+      </section>
+    </div>
+  </section>
+</div>

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -406,7 +406,7 @@ RSpec.describe RepositoriesController, type: :controller do
             }
         expect(response).to redirect_to password_entry_repository_path(
                       Repository.last.user_username,
-                      Repository.last.slug
+                      Repository.last.id
                     )
         expect(flash[:alert]).to eq("Incorrect password. Try again!")
       end


### PR DESCRIPTION
- Fixed a routing issue that would occur when entering an incorrect password in a private repository
- Fixed users being able to go to `/password_entry` in a public repo