### PR TITLE
Feat/3d printer management

### DIFF
--- a/app/controllers/printers_controller.rb
+++ b/app/controllers/printers_controller.rb
@@ -41,7 +41,7 @@ class PrintersController < StaffAreaController
       flash[:alert] = "Please add both printer and user."
     elsif user_id == "0" && last_session.update(in_use: false)
       flash[:notice] = "Cleared the user."
-    elsif last_session.in_use?
+    elsif !last_session.nil? && last_session.in_use?
       flash[:alert] = "This printer is already being used by another user."
     elsif PrinterSession.create(
           printer_id: printer_id,

--- a/app/controllers/staff_dashboard_controller.rb
+++ b/app/controllers/staff_dashboard_controller.rb
@@ -13,6 +13,8 @@ class StaffDashboardController < StaffAreaController
               .where(trainings: { spaces: { id: space_id } })
           end
         @all_user_certs = Proc.new { |user| user.certifications }
+        @printers_in_use =
+          PrinterSession.order(created_at: :desc).where(in_use: true)
       end
       format.json do
         render json: {

--- a/app/views/printers/staff_printers.html.erb
+++ b/app/views/printers/staff_printers.html.erb
@@ -1,4 +1,4 @@
-<section class="padding">
+<section class="padding mt-4">
 
     <div class="title">Manage 3D-Printers Usage</div>
 

--- a/app/views/printers/staff_printers_updates.html.erb
+++ b/app/views/printers/staff_printers_updates.html.erb
@@ -1,4 +1,4 @@
-<section class="padding">
+<section class="padding-10 mt-4">
 
   <div>
 
@@ -17,6 +17,7 @@
               <th>Printer Number</th>
               <th>User</th>
               <th>Time</th>
+              <th>In Use</th>
             </thead>
             <tbody>
               <% Printer.get_printer_ids(type).sort_by { |printer| Printer.get_last_number_session(printer).created_at }.reverse.each do |printer_id| %>
@@ -25,6 +26,7 @@
                   <td><%= Printer.find(printer_id).number %></td>
                   <td><%= link_to last_session.user.username, user_path(last_session.user.username) %></td>
                   <td><%= last_session&.created_at&.strftime('%a, %d %b %Y at %I:%M%p') %></td>
+                  <td><%= last_session.in_use? ? 'Yes' : 'No' %></td>
                 </tr>
               <% end %>
 

--- a/app/views/staff_dashboard/_signed_in_table.html.erb
+++ b/app/views/staff_dashboard/_signed_in_table.html.erb
@@ -34,6 +34,13 @@
                     <% end %>
                 <% end %>
             </td>
+            <% if @space.makerspace? %>
+              <td class="printers-cell">
+                <% @printers_in_use.where(user_id: user.id).each do |printer_session| %>
+                  <%= printer_session.printer.number %>
+                <% end %>
+              </td>
+            <% end %>
             <td class="email-cell">
                 <%= user.lab_sessions.where('space_id' => @space.id).where('created_at BETWEEN ? AND ? ', 2.months.ago, DateTime.now).count %>
             </td>

--- a/app/views/staff_dashboard/_signed_in_table.html.erb
+++ b/app/views/staff_dashboard/_signed_in_table.html.erb
@@ -37,7 +37,7 @@
             <% if @space.makerspace? %>
               <td class="printers-cell">
                 <% @printers_in_use.where(user_id: user.id).each do |printer_session| %>
-                  <%= printer_session.printer.number %>
+                  <p class="m-0"><%= printer_session.printer.number %></p>
                 <% end %>
               </td>
             <% end %>

--- a/app/views/staff_dashboard/index.html.erb
+++ b/app/views/staff_dashboard/index.html.erb
@@ -42,6 +42,9 @@
             <th class="email-header">Email</th>
             <th class="name-header">Flagged?</th>
             <th class="certifications-header">Certifications in <%= @space.name %></th>
+            <% if @space.makerspace? %>
+              <th class="printers-header">Assigned Printers</th>
+            <% end %>
             <th class="email-header"> # of visits <br> (Past 2 months)</th>
             <th class="last-seen-header">Last Seen</th>
             <th class="action-header disable-sort">Sign Out of <%= @space.name %></th>

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -63,6 +63,10 @@ every :day, at: "2am" do
   rake "active_volunteers:check_volunteers_status"
 end
 
+every :day, at: "2:30am" do
+  rake "printers:clear_printers"
+end
+
 every :day, at: "11:59pm" do
   rake "exams:check_expired_exams"
 end

--- a/db/migrate/20230725202024_add_in_use_to_printer_sessions.rb
+++ b/db/migrate/20230725202024_add_in_use_to_printer_sessions.rb
@@ -1,0 +1,5 @@
+class AddInUseToPrinterSessions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :printer_sessions, :in_use, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_25_202024) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -19,7 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
     t.string "name", null: false
     t.text "body"
     t.string "record_type", null: false
-    t.integer "record_id", null: false
+    t.bigint "record_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index %w[record_type record_id name],
@@ -52,7 +52,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.integer "blob_id", null: false
+    t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index %w[blob_id variation_digest],
             name: "index_active_storage_variant_records_uniqueness",
@@ -113,6 +113,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
     t.string "list_of_skills"
     t.bigint "training_id"
     t.string "training_level"
+    t.string "badge_url"
     t.index ["training_id"], name: "index_badge_templates_on_training_id"
   end
 
@@ -127,7 +128,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
     t.bigint "certification_id"
     t.index ["badge_template_id"], name: "index_badges_on_badge_template_id"
     t.index ["certification_id"], name: "index_badges_on_certification_id"
-    t.index ["user_id"], name: "index_badges_on_user_id"
   end
 
   create_table "booking_statuses", force: :cascade do |t|
@@ -281,6 +281,23 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
     t.integer "score"
     t.integer "training_session_id"
     t.datetime "expired_at", precision: nil
+  end
+
+  create_table "friendly_id_slugs", id: :serial, force: :cascade do |t|
+    t.string "slug", null: false
+    t.integer "sluggable_id", null: false
+    t.string "sluggable_type", limit: 50
+    t.string "scope"
+    t.datetime "created_at", precision: nil
+    t.index %w[slug sluggable_type scope],
+            name:
+              "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope",
+            unique: true
+    t.index %w[slug sluggable_type],
+            name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
+    t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
+    t.index ["sluggable_type"],
+            name: "index_friendly_id_slugs_on_sluggable_type"
   end
 
   create_table "job_options", force: :cascade do |t|
@@ -470,8 +487,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
 
   create_table "learning_module_tracks", force: :cascade do |t|
     t.string "status", default: "In progress"
-    t.integer "learning_module_id"
-    t.integer "user_id"
+    t.bigint "learning_module_id"
+    t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["learning_module_id"],
@@ -502,7 +519,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
     t.string "students"
     t.string "public"
     t.string "summer"
-    t.integer "contact_info_id"
+    t.bigint "contact_info_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["contact_info_id"], name: "index_opening_hours_on_contact_info_id"
@@ -517,9 +534,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "status", default: "In progress"
-    t.index ["order_id"], name: "index_order_items_on_order_id"
-    t.index ["proficient_project_id"],
-            name: "index_order_items_on_proficient_project_id"
+    t.text "user_comments", default: ""
+    t.text "admin_comments", default: ""
   end
 
   create_table "order_statuses", id: :serial, force: :cascade do |t|
@@ -535,13 +551,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.integer "user_id"
-    t.index ["order_status_id"], name: "index_orders_on_order_status_id"
   end
 
   create_table "photos", id: :serial, force: :cascade do |t|
     t.integer "repository_id"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.string "image_file_name"
+    t.string "image_content_type"
+    t.integer "image_file_size"
+    t.datetime "image_updated_at", precision: nil
     t.integer "height"
     t.integer "width"
     t.integer "proficient_project_id"
@@ -560,7 +579,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
   end
 
   create_table "popular_hours", force: :cascade do |t|
-    t.integer "space_id"
+    t.bigint "space_id"
     t.float "mean", default: 0.0
     t.integer "hour"
     t.integer "day"
@@ -589,6 +608,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
     t.text "comments"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.string "file_file_name"
+    t.string "file_content_type"
+    t.integer "file_file_size"
+    t.datetime "file_updated_at", precision: nil
     t.float "quote"
     t.integer "staff_id"
     t.boolean "user_approval"
@@ -596,6 +619,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
     t.boolean "expedited"
     t.integer "order_type", default: 0
     t.datetime "timestamp_approved", precision: nil
+    t.string "final_file_file_name"
+    t.string "final_file_content_type"
+    t.integer "final_file_file_size"
+    t.datetime "final_file_updated_at", precision: nil
     t.float "grams"
     t.float "service_charge"
     t.float "price_per_hour"
@@ -621,6 +648,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
     t.datetime "updated_at", precision: nil, null: false
     t.integer "user_id"
     t.integer "printer_id"
+    t.boolean "in_use", default: false
   end
 
   create_table "printers", id: :serial, force: :cascade do |t|
@@ -641,6 +669,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
     t.integer "badge_template_id"
     t.boolean "has_project_kit"
     t.bigint "drop_off_location_id"
+    t.boolean "is_virtual", default: false
     t.index ["badge_template_id"],
             name: "index_proficient_projects_on_badge_template_id"
     t.index ["drop_off_location_id"],
@@ -668,8 +697,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
   end
 
   create_table "project_kits", force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "proficient_project_id"
+    t.bigint "user_id"
+    t.bigint "proficient_project_id"
     t.string "name"
     t.boolean "delivered", default: false
     t.datetime "created_at", null: false
@@ -721,6 +750,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
     t.text "description"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.string "image_file_name"
+    t.string "image_content_type"
+    t.integer "image_file_size"
+    t.datetime "image_updated_at", precision: nil
     t.integer "training_id"
     t.string "level", default: "Beginner"
   end
@@ -743,6 +776,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
     t.integer "repository_id"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.string "file_file_name"
+    t.string "file_content_type"
+    t.integer "file_file_size"
+    t.datetime "file_updated_at", precision: nil
     t.integer "proficient_project_id"
     t.integer "learning_module_id"
     t.integer "project_proposal_id"
@@ -795,7 +832,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
   end
 
   create_table "shadowing_hours", force: :cascade do |t|
-    t.integer "user_id"
+    t.bigint "user_id"
     t.string "event_id"
     t.datetime "start_time", precision: nil
     t.datetime "end_time", precision: nil
@@ -808,7 +845,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
 
   create_table "shifts", force: :cascade do |t|
     t.text "reason"
-    t.integer "space_id"
+    t.bigint "space_id"
     t.datetime "start_datetime", precision: nil
     t.datetime "end_datetime", precision: nil
     t.datetime "created_at", null: false
@@ -839,7 +876,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
     t.time "start_time"
     t.time "end_time"
     t.integer "day"
-    t.integer "space_id"
+    t.bigint "space_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "language"
@@ -866,7 +903,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
   end
 
   create_table "staff_availabilities", force: :cascade do |t|
-    t.integer "user_id"
+    t.bigint "user_id"
     t.string "day"
     t.time "start_time"
     t.time "end_time"
@@ -888,8 +925,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
   end
 
   create_table "staff_spaces", force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "space_id"
+    t.bigint "user_id"
+    t.bigint "space_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "color"
@@ -1021,6 +1058,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
     t.datetime "updated_at", precision: nil, null: false
     t.text "description"
     t.string "email"
+    t.string "avatar_file_name"
+    t.string "avatar_content_type"
+    t.integer "avatar_file_size"
+    t.datetime "avatar_updated_at", precision: nil
     t.string "access_token"
     t.string "name"
     t.string "gender"
@@ -1028,7 +1069,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_212738) do
     t.string "use"
     t.integer "reputation", default: 0
     t.string "role", default: "regular_user"
-    t.boolean "terms_and_conditions", default: true
+    t.boolean "terms_and_conditions"
     t.string "program"
     t.string "how_heard_about_us"
     t.string "identity"

--- a/lib/tasks/printers.rake
+++ b/lib/tasks/printers.rake
@@ -1,0 +1,9 @@
+namespace :printers do
+  desc "Clear all in use printer sessions"
+  task clear_printers: :environment do
+    printers_in_use = PrinterSession.where(in_use: true)
+    printers_in_use.each do |printer_session|
+      printers_in_use.update(in_use: false)
+    end
+  end
+end


### PR DESCRIPTION
## Description
- Added an `in_use` boolean column to `PrinterSessions` to track which printers are being used
- Added an "Assigned Printers" column in the MakerSpace staff kiosk
- Added a "Clear" option in the User dropdown for the 3D printer management page
- Created a cron job to clear all in use printer sessions everyday at 2:30am

## Screenshots
![Screenshot 2023-07-26 at 1 17 49 PM](https://github.com/uOttawa-Makerspace/MakerSpaceRepo/assets/75919484/165b87c0-3fde-4868-adbd-1f86d88fd8a4)
![Screenshot 2023-07-26 at 1 18 12 PM](https://github.com/uOttawa-Makerspace/MakerSpaceRepo/assets/75919484/ed5a0253-b820-4c5c-a87d-eb951aaf836f)

