### PR TITLE
Feature/print failed message

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -8,6 +8,7 @@ class Admin::SettingsController < AdminAreaController
     @cat_option = CategoryOption.new
     @pi_option = PiReader.new
     @job_order_processed_message = JobOrderMessage.find_by(name: "processed")
+    @print_failed_message = JobOrderMessage.print_failed
     @area_option = AreaOption.new
   end
 
@@ -153,12 +154,27 @@ class Admin::SettingsController < AdminAreaController
   end
 
   def update_job_order_processed
-    if params[:job_order_message].present? &&
-         params[:job_order_message][:message].present?
-      PrintOrderMessage.find_by(name: "processed").update(
-        message: params[:job_order_message][:message]
-      )
-      flash[:notice] = "Message updated successfully!"
+    msg = params.dig(:job_order_message, :message)
+    if msg
+      if JobOrderMessage.find_by(name: "processed").update(message: msg)
+        flash[:notice] = "Message updated successfully!"
+      else
+        flash[:alert] = "Message update failed."
+      end
+    else
+      flash[:alert] = "Please enter a message."
+    end
+    redirect_to admin_settings_path
+  end
+
+  def update_print_failed_message
+    msg = params.dig(:job_order_message, :message)
+    if msg
+      if JobOrderMessage.print_failed.update(message: msg)
+        flash[:notice] = "Message updated successfully!"
+      else
+        flash[:alert] = "Message update failed"
+      end
     else
       flash[:alert] = "Please enter a message."
     end

--- a/app/controllers/printer_types_controller.rb
+++ b/app/controllers/printer_types_controller.rb
@@ -65,7 +65,7 @@ class PrinterTypesController < StaffAreaController
   private
 
   def printer_type_params
-    params.require(:printer_type).permit(:name, :short_form)
+    params.require(:printer_type).permit(:name, :short_form, :available)
   end
 
   def get_printer_type

--- a/app/controllers/printer_types_controller.rb
+++ b/app/controllers/printer_types_controller.rb
@@ -30,30 +30,12 @@ class PrinterTypesController < StaffAreaController
   end
 
   def update
-    previous_short_form = @printer_type.short_form
-
     if @printer_type.update(printer_type_params)
-      if previous_short_form != @printer_type.short_form
-        new_short_form = @printer_type.short_form
-
-        new_short_form += " - " if previous_short_form.blank?
-        previous_short_form += " - " if new_short_form.blank?
-
-        @printer_type.printers.each do |printer|
-          unless printer.number.start_with?(new_short_form) &&
-                   previous_short_form.blank?
-            new_number = printer.number.sub(previous_short_form, new_short_form)
-            printer.update(number: new_number)
-          end
-        end
-      end
-
-      redirect_to printer_types_path,
-                  notice: "Successfully updated printer model"
+      flash[:notice] = "Successfully updated printer model"
     else
       flash[:alert] = "Failed to update printer model"
-      redirect_back(fallback_location: printer_types_path)
     end
+    redirect_to printer_types_path
   end
 
   def destroy

--- a/app/controllers/printers_controller.rb
+++ b/app/controllers/printers_controller.rb
@@ -99,11 +99,26 @@ class PrintersController < StaffAreaController
     msg_params = params[:print_failed_message]
     print_owner = User.find_by(username: msg_params[:username])
     printer = Printer.find_by(number: msg_params[:printer_number])
-    MsrMailer.print_failed(
-      printer,
-      print_owner,
-      msg_params[:staff_notes]
-    ).deliver_now
+
+    if printer.nil?
+      flash[:alert] = "Error sending message, printer not found"
+    elsif print_owner.nil?
+      flash[:alert] = "Error sending message, username not found"
+    else
+      MsrMailer.print_failed(
+        printer,
+        print_owner,
+        msg_params[:staff_notes]
+      ).deliver_now
+
+      flash[:notice] = "Email sent successfully"
+    end
+
+    if msg_params[:sent_from] == "updates"
+      redirect_to staff_printers_updates_printers_url
+    elsif msg_params[:sent_from] == "printers"
+      redirect_to staff_printers_printers_url #(anchor: 'failedPrintHeader')
+    end
   end
 
   private

--- a/app/controllers/printers_controller.rb
+++ b/app/controllers/printers_controller.rb
@@ -17,7 +17,12 @@ class PrintersController < StaffAreaController
   end
 
   def update
-    Printer.find_by(id: params[:id]).update(printer_params)
+    if Printer.find_by(id: params[:id]).update(printer_params)
+      flash[:notice] = "Printer updated"
+    else
+      flash[:alert] = "Failed to update printer"
+    end
+
     redirect_to printers_path
   end
 
@@ -35,7 +40,11 @@ class PrintersController < StaffAreaController
       end
     end
     # pass the model to keep selection
-    redirect_to printers_path(model_id: params[:model_id])
+    if params[:model_id]&.empty?
+      redirect_to printers_path
+    else
+      redirect_to printers_path(model_id: params[:model_id])
+    end
   end
 
   def remove_printer

--- a/app/controllers/printers_controller.rb
+++ b/app/controllers/printers_controller.rb
@@ -95,6 +95,17 @@ class PrintersController < StaffAreaController
     redirect_to staff_printers_printers_path
   end
 
+  def send_print_failed_message_to_user
+    msg_params = params[:print_failed_message]
+    print_owner = User.find_by(username: msg_params[:username])
+    printer = Printer.find_by(number: msg_params[:printer_number])
+    MsrMailer.print_failed(
+      printer,
+      print_owner,
+      msg_params[:staff_notes]
+    ).deliver_now
+  end
+
   private
 
   def ensure_admin

--- a/app/controllers/printers_controller.rb
+++ b/app/controllers/printers_controller.rb
@@ -14,6 +14,12 @@ class PrintersController < StaffAreaController
         .map do |pt|
           [pt.name + (pt.short_form.blank? ? "" : " (#{pt.short_form})"), pt.id]
         end
+    # Sort by length then by value, solves the "1 then 10" issue
+    @printers_by_type =
+      Printer
+        .all
+        .sort_by { |p| [p.number.length, p.number] }
+        .group_by(&:printer_type)
   end
 
   def add_printer
@@ -29,7 +35,8 @@ class PrintersController < StaffAreaController
         flash[:alert] = "Printer number already exists"
       end
     end
-    redirect_to printers_path
+    # pass the model to keep selection
+    redirect_to printers_path(model_id: params[:model_id])
   end
 
   def remove_printer

--- a/app/controllers/printers_controller.rb
+++ b/app/controllers/printers_controller.rb
@@ -17,19 +17,10 @@ class PrintersController < StaffAreaController
   end
 
   def add_printer
-    printer_type = PrinterType.find_by(id: params[:model_id])
-
     if params[:printer][:number].blank? || params[:model_id].blank?
       flash[:alert] = "Invalid printer model or number"
     else
-      number =
-        (
-          if printer_type.short_form.blank?
-            params[:printer][:number]
-          else
-            "#{printer_type.short_form} - #{params[:printer][:number]}"
-          end
-        )
+      number = params[:printer][:number]
 
       @printer = Printer.new(number: number, printer_type_id: params[:model_id])
       if @printer.save
@@ -98,7 +89,7 @@ class PrintersController < StaffAreaController
   def send_print_failed_message_to_user
     msg_params = params[:print_failed_message]
     print_owner = User.find_by(username: msg_params[:username])
-    printer = Printer.find_by(number: msg_params[:printer_number])
+    printer = Printer.find_by(id: msg_params[:printer_number])
 
     if printer.nil?
       flash[:alert] = "Error sending message, printer not found"

--- a/app/controllers/printers_controller.rb
+++ b/app/controllers/printers_controller.rb
@@ -14,12 +14,11 @@ class PrintersController < StaffAreaController
         .map do |pt|
           [pt.name + (pt.short_form.blank? ? "" : " (#{pt.short_form})"), pt.id]
         end
-    # Sort by length then by value, solves the "1 then 10" issue
-    @printers_by_type =
-      Printer
-        .all
-        .sort_by { |p| [p.number.length, p.number] }
-        .group_by(&:printer_type)
+  end
+
+  def update
+    Printer.find_by(id: params[:id]).update(printer_params)
+    redirect_to printers_path
   end
 
   def add_printer
@@ -64,6 +63,12 @@ class PrintersController < StaffAreaController
         .pluck(:name, :id)
     @list_users.unshift(%w[Clear clear])
     @printer_types = PrinterType.all.order("lower(name) ASC")
+    # Sort by length then by value, solves the "1 then 10" issue
+    @printers_by_type =
+      Printer
+        .all
+        .sort_by { |p| [p.number.length, p.number] }
+        .group_by(&:printer_type)
   end
 
   def staff_printers_updates
@@ -120,6 +125,14 @@ class PrintersController < StaffAreaController
   end
 
   private
+
+  def printer_params
+    if current_user.admin?
+      params.require(:printer).permit(:number, :maintenance)
+    else
+      params.require(:printer).permit(:maintenance)
+    end
+  end
 
   def ensure_admin
     @user = current_user

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -76,8 +76,8 @@ module ApplicationHelper
 
   private
 
-  def page_title(curr_page = "")
-    base_title = "MakerRepo"
+  def page_title(curr_page = "", base_title: "MakerRepo")
+    #base_title = "MakerRepo"
     curr_page.empty? ? base_title : curr_page + " | " + base_title
   end
 

--- a/app/javascript/entrypoints/printers.js
+++ b/app/javascript/entrypoints/printers.js
@@ -1,0 +1,11 @@
+import TomSelect from "tom-select";
+new TomSelect("#remove_printer", {});
+
+document.getElementById("model_id").addEventListener("change", (event) => {
+  document.getElementById("newPrinterCode").innerText = event.target.options[
+    event.target.selectedIndex
+  ].text
+    .match(/\((.*)\)/)
+    .pop();
+});
+document.getElementById("model_id").dispatchEvent(new Event("change"));

--- a/app/javascript/entrypoints/staff_dashboard_search.js
+++ b/app/javascript/entrypoints/staff_dashboard_search.js
@@ -1,4 +1,6 @@
 import TomSelect from "tom-select";
+// This is also used in printers/_send_print_failed_form
+// make sure you don't break that too
 if (!document.getElementById("user_dashboard_select").tomsselect) {
   new TomSelect("#user_dashboard_select", {
     searchField: ["name"],
@@ -30,9 +32,11 @@ if (!document.getElementById("user_dashboard_select").tomsselect) {
   });
 }
 let form = document.getElementById("sign_in_user_fastsearch");
-form.onsubmit = function () {
-  document.getElementById("sign_in_user_fastsearch_username").value = [
-    document.getElementById("user_dashboard_select").value,
-  ];
-  form.submit();
-};
+if (form) {
+  form.onsubmit = function () {
+    document.getElementById("sign_in_user_fastsearch_username").value = [
+      document.getElementById("user_dashboard_select").value,
+    ];
+    form.submit();
+  };
+}

--- a/app/javascript/entrypoints/staff_printers.js
+++ b/app/javascript/entrypoints/staff_printers.js
@@ -1,5 +1,11 @@
 import TomSelect from "tom-select";
-new TomSelect("#ultimaker2p", {});
-new TomSelect("#ultimaker3", {});
-new TomSelect("#replicator2", {});
-new TomSelect("#dremel", {});
+const all_selects = ["#ultimaker2p", "#ultimaker3", "#replicator2", "#dremel"];
+for (let i = 0; i < all_selects.length; i++) {
+  try {
+    new TomSelect(all_selects[i], {});
+  } catch (e) {} // nothing to catch O_O
+}
+
+try {
+  new TomSelect("#printerNumberSelect", { items: [] }); // To claer default value
+} catch (e) {}

--- a/app/javascript/entrypoints/staff_printers_updates.js
+++ b/app/javascript/entrypoints/staff_printers_updates.js
@@ -9,6 +9,7 @@ window.populateMessageModal = function (element) {
   user_select.setValue(element.dataset.username); // Set that username
   document.getElementById("printerNumberSelect").value =
     element.dataset.printerNumber; // printers are already loaded - this isn't a tomselect i think
+  document.getElementById("print_failed_message_staff_notes").value = "";
 };
 document.querySelectorAll(".print-failed-button").forEach((e) => {
   e.addEventListener("click", (event) => populateMessageModal(event.target));

--- a/app/javascript/entrypoints/staff_printers_updates.js
+++ b/app/javascript/entrypoints/staff_printers_updates.js
@@ -1,0 +1,15 @@
+window.populateMessageModal = function (element) {
+  //console.log(element.dataset.username + ' / ' + element.dataset.printerNumber)
+  let user_select = document.getElementById("user_dashboard_select").tomselect;
+  user_select.clearOptions(); // Clear prev options
+  user_select.addOption({
+    id: element.dataset.username,
+    name: element.dataset.username,
+  }); // Add our username manually
+  user_select.setValue(element.dataset.username); // Set that username
+  document.getElementById("printerNumberSelect").value =
+    element.dataset.printerNumber; // printers are already loaded - this isn't a tomselect i think
+};
+document.querySelectorAll(".print-failed-button").forEach((e) => {
+  e.addEventListener("click", (event) => populateMessageModal(event.target));
+});

--- a/app/mailers/msr_mailer.rb
+++ b/app/mailers/msr_mailer.rb
@@ -318,7 +318,10 @@ class MsrMailer < ApplicationMailer
       reply_to: "makerspace@uottawa.ca",
       bcc: "uottawa.makerepo@gmail.com",
       subject: "Your 3D print on #{printer.number} has failed"
-    )
+    ) do |format|
+      format.html { render layout: "msr_mailer" } # special case, use consistent layout
+      #format.text # We don't send text mail, should strip tags do that sometime
+    end
   end
 
   # Not in use currently

--- a/app/mailers/msr_mailer.rb
+++ b/app/mailers/msr_mailer.rb
@@ -304,6 +304,23 @@ class MsrMailer < ApplicationMailer
     mail(to: "makerspace@uottawa.ca", subject: "Weekly Reports", bcc: to)
   end
 
+  # This is sent by staff when a printer fails and it has someone
+  # assigned to it, so they come back and restart it instead of waiting
+  # 7 hours to receive a pile of plastic
+  def print_failed(printer, user, notes)
+    @message =
+      JobOrderMessage
+        .print_failed
+        .format_print_failed(printer, user, notes)
+        .html_safe
+    mail(
+      to: user.email,
+      reply_to: "makerspace@uottawa.ca",
+      bcc: "uottawa.makerepo@gmail.com",
+      subject: "Your 3D print on #{printer.number} has failed"
+    )
+  end
+
   # Not in use currently
   # def send_checklist_reminder(email, master_email)
   #   @email = email

--- a/app/models/job_order_message.rb
+++ b/app/models/job_order_message.rb
@@ -33,15 +33,15 @@ class JobOrderMessage < ApplicationRecord
   end
 
   # Generated formatted message for printer
-  def format_print_failed(printer_id, user_id, notes)
-    printer = Printer.find_by_id(printer_id)
-    print_owner = User.find_by_id(user_id)
-    if printer && print_owner
+  def format_print_failed(printer, user, notes)
+    if printer && user
       message
         .gsub("[PRINTER_NUMBER]", printer.number)
-        .gsub("[PRINT_OWNER_NAME]", print_owner.name)
-        .gsub("[PRINT_OWNER_USERNAME]", print_owner.username)
+        .gsub("[PRINT_OWNER_NAME]", user.name)
+        .gsub("[PRINT_OWNER_USERNAME]", user.username)
         .gsub("[STAFF_NOTES]", notes)
+    else
+      message
     end
   end
 end

--- a/app/models/job_order_message.rb
+++ b/app/models/job_order_message.rb
@@ -2,6 +2,15 @@ class JobOrderMessage < ApplicationRecord
   validates :name, presence: true, uniqueness: true
   validates :message, presence: true
 
+  def self.print_failed
+    # this won't be created first time
+    # fails if we don't supply a default message
+    create_with(message: "Print failed").find_or_create_by!(
+      name: "print_failed"
+    )
+  end
+
+  # Generate formatted message for job id
   def retrieve_message(job_id)
     print_id = "[PRINT_ID]"
     quote_balance = "[QUOTED_BALANCE]"
@@ -20,6 +29,19 @@ class JobOrderMessage < ApplicationRecord
       new_message
     else
       message
+    end
+  end
+
+  # Generated formatted message for printer
+  def format_print_failed(printer_id, user_id, notes)
+    printer = Printer.find_by_id(printer_id)
+    print_owner = User.find_by_id(user_id)
+    if printer && print_owner
+      message
+        .gsub("[PRINTER_NUMBER]", printer.number)
+        .gsub("[PRINT_OWNER_NAME]", print_owner.name)
+        .gsub("[PRINT_OWNER_USERNAME]", print_owner.username)
+        .gsub("[STAFF_NOTES]", notes)
     end
   end
 end

--- a/app/models/job_order_message.rb
+++ b/app/models/job_order_message.rb
@@ -36,7 +36,7 @@ class JobOrderMessage < ApplicationRecord
   def format_print_failed(printer, user, notes)
     if printer && user
       message
-        .gsub("[PRINTER_NUMBER]", printer.number)
+        .gsub("[PRINTER_NUMBER]", printer.name)
         .gsub("[PRINT_OWNER_NAME]", user.name)
         .gsub("[PRINT_OWNER_USERNAME]", user.username)
         .gsub("[STAFF_NOTES]", notes)

--- a/app/models/printer.rb
+++ b/app/models/printer.rb
@@ -7,8 +7,12 @@ class Printer < ApplicationRecord
 
   validates :number, presence: true, uniqueness: { scope: :printer_type_id }
 
+  def name
+    "#{printer_type&.short_form} - #{number}"
+  end
+
   def model_and_number
-    "#{printer_type.name}; Number #{number}"
+    "#{printer_type.name}; #{name}"
   end
 
   def self.get_printer_ids(model)

--- a/app/models/printer_type.rb
+++ b/app/models/printer_type.rb
@@ -3,4 +3,7 @@ class PrinterType < ApplicationRecord
   has_many :printer_sessions, through: :printers
 
   validates :name, presence: true, uniqueness: true
+
+  scope :available, -> { where(available: true) }
+  scope :unavailable, -> { where(available: false) }
 end

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -66,14 +66,24 @@
       <br><br>
     </div>
     <div class="col-md-6">
-      <h5>Job Order Processed default email</h5><hr>
-      <p>[QUOTED_BALANCE] = Balance given to user, [PRINT_ID] = Job Order ID</p>
-      <%= form_for @job_order_processed_message, url: { controller: 'admin/settings', action: 'update_job_order_processed' } do |f| %>
-        <%= f.trix_editor :message, class: 'repo form-control mb-2', style: 'height: auto!important;' %>
+      <div class="mb-5">
+        <h5>Job Order Processed default email</h5><hr/>
+        <p>[QUOTED_BALANCE] = Balance given to user, [PRINT_ID] = Job Order ID</p>
+        <%= form_for @job_order_processed_message, url: update_job_order_processed_admin_settings_path do |f| %>
+          <%= f.trix_editor :message, class: 'repo form-control mb-2', style: 'height: auto!important;' %>
 
-        <%= f.submit 'Update', class: 'btn btn-primary' %>
-      <% end %>
-      <br><br>
+          <%= f.submit 'Update', class: 'btn btn-primary' %>
+        <% end %>
+      </div>
+      <div>
+        <h5>Print Failed default email</h5><hr/>
+        <p>[PRINTER_NUMBER] = Printer number, [PRINT_OWNER_NAME] = Print owner full name,
+          [PRINT_OWNER_USERNAME] = Print owner username, [STAFF_NOTES] = Staff notes</p>
+        <%= form_for @print_failed_message, url: update_print_failed_message_admin_settings_path do |f| %>
+          <%= f.trix_editor :message, class: 'repo form-control mb-2', style: 'height: auto!important;' %>
+          <%= f.submit 'Update', class: 'btn btn-primary' %>
+        <% end %>
+      </div>
     </div>
     <div class="col-md-6">
       <h5>Course Options</h5><hr>

--- a/app/views/layouts/msr_mailer.html.erb
+++ b/app/views/layouts/msr_mailer.html.erb
@@ -1,0 +1,152 @@
+<html>
+<head>
+  <meta name="viewport" content="width=device-width">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>Transactional Email</title>
+  <style>
+      @media only screen and (max-width: 620px) {
+          table[class=body] h1 {
+              font-size: 28px !important;
+              margin-bottom: 10px !important;
+          }
+
+          table[class=body] p,
+          table[class=body] ul,
+          table[class=body] ol,
+          table[class=body] td,
+          table[class=body] span,
+          table[class=body] a {
+              font-size: 16px !important;
+          }
+
+          table[class=body] .wrapper,
+          table[class=body] .article {
+              padding: 10px !important;
+          }
+
+          table[class=body] .content {
+              padding: 0 !important;
+          }
+
+          table[class=body] .container {
+              padding: 0 !important;
+              width: 100% !important;
+          }
+
+          table[class=body] .main {
+              border-left-width: 0 !important;
+              border-radius: 0 !important;
+              border-right-width: 0 !important;
+          }
+
+          table[class=body] .btn table {
+              width: 100% !important;
+          }
+
+          table[class=body] .btn a {
+              width: 100% !important;
+          }
+
+          table[class=body] .img-responsive {
+              height: auto !important;
+              max-width: 100% !important;
+              width: auto !important;
+          }
+      }
+      @media all {
+          .ExternalClass {
+              width: 100%;
+          }
+
+          .ExternalClass,
+          .ExternalClass p,
+          .ExternalClass span,
+          .ExternalClass font,
+          .ExternalClass td,
+          .ExternalClass div {
+              line-height: 100%;
+          }
+
+          .apple-link a {
+              color: inherit !important;
+              font-family: inherit !important;
+              font-size: inherit !important;
+              font-weight: inherit !important;
+              line-height: inherit !important;
+              text-decoration: none !important;
+          }
+
+          #MessageViewBody a {
+              color: inherit;
+              text-decoration: none;
+              font-size: inherit;
+              font-family: inherit;
+              font-weight: inherit;
+              line-height: inherit;
+          }
+
+          .btn-primary table td:hover {
+              background-color: #34495e !important;
+          }
+
+          .btn-primary a:hover {
+              background-color: #34495e !important;
+              border-color: #34495e !important;
+          }
+      }
+  </style>
+</head>
+<body class="" style="background-color: #f6f6f6; font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.4; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
+<span class="preheader" style="color: transparent; display: none; height: 0; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all; visibility: hidden; width: 0;">Makerepo - Welcome to MakerRepo</span>
+<table role="presentation" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #f6f6f6; width: 100%;" width="100%" bgcolor="#f6f6f6">
+  <tr>
+    <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top">&nbsp;</td>
+    <td class="container" style="font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; max-width: 580px; padding: 10px; width: 580px; margin: 0 auto;" width="580" valign="top">
+      <div class="content" style="box-sizing: border-box; display: block; margin: 0 auto; max-width: 580px; padding: 10px;">
+
+        <!-- START CENTERED WHITE CONTAINER -->
+        <table role="presentation" class="main" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background: #ffffff; border-radius: 3px; width: 100%;" width="100%">
+
+          <!-- START MAIN CONTENT AREA -->
+          <tr>
+            <td class="wrapper" style="font-family: sans-serif; font-size: 14px; vertical-align: top; box-sizing: border-box; padding: 20px;" valign="top">
+              <table role="presentation" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;" width="100%">
+                <tr>
+                  <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top">
+                    <%= image_tag('ceed.png', alt: 'CEED Logo', width: 120, height: 34, border: 0, style: 'border:0; outline:none; text-decoration:none; display:block;') %>
+                    <br>
+                    <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;"><%= yield %></p>
+                    <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">
+                      Thank you,<br>
+                      <b>CEED Team</b>
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- END MAIN CONTENT AREA -->
+        </table>
+        <!-- END CENTERED WHITE CONTAINER -->
+
+        <!-- START FOOTER -->
+        <div class="footer" style="clear: both; margin-top: 10px; text-align: center; width: 100%;">
+          <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;" width="100%">
+            <tr>
+              <td class="content-block" style="font-family: sans-serif; vertical-align: top; padding-bottom: 10px; padding-top: 10px; color: #999999; font-size: 12px; text-align: center;" valign="top" align="center">
+                <span class="apple-link" style="color: #999999; font-size: 12px; text-align: center;">CEED, 150 Louis Pasteur, Ottawa ON Canada K1N 6N5</span>
+                <p style="font-family: sans-serif; font-weight: normal; margin: 0; margin-bottom: 15px; color: #999999; font-size: 12px; text-align: center;"><%= yield :why_received %></p>
+              </td>
+            </tr>
+          </table>
+        </div>
+        <!-- END FOOTER -->
+
+      </div>
+    </td>
+    <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top">&nbsp;</td>
+  </tr>
+</table>
+</body>
+</html>

--- a/app/views/layouts/staff_area.html.erb
+++ b/app/views/layouts/staff_area.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Staff Area</title>
+  <title><%= page_title(yield(:title), base_title: 'Staff Area | MakerRepo') %></title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <%= favicon_link_tag 'site-icon.jpg' %>
     <%= stylesheet_link_tag 'vendor', media: 'all', debug: false %>

--- a/app/views/msr_mailer/print_failed.html.erb
+++ b/app/views/msr_mailer/print_failed.html.erb
@@ -1,2 +1,2 @@
-<h1>UR PRINT FAILED LMAO LOSER</h1>
+<% provide :why_received, 'You have received this email because you started a print job at the MakerSpace' %>
 <%= @message %>

--- a/app/views/msr_mailer/print_failed.html.erb
+++ b/app/views/msr_mailer/print_failed.html.erb
@@ -1,0 +1,2 @@
+<h1>UR PRINT FAILED LMAO LOSER</h1>
+<%= @message %>

--- a/app/views/printer_types/edit.html.erb
+++ b/app/views/printer_types/edit.html.erb
@@ -14,6 +14,10 @@
               <%= f.label :short_form, 'Short Form (Optional)', class: 'form-label' %>
               <%= f.text_field :short_form, class: 'form-control' %>
             </div>
+            <div class="mb-3">
+              <%= f.check_box :available, class: 'form-check-input' %>
+              <%= f.label :available, 'Is available for use?', class: 'form-label' %>
+            </div>
 
             <div class="text-center">
               <%= f.submit 'Update Printer Model', class: 'btn btn-primary' %>

--- a/app/views/printer_types/index.html.erb
+++ b/app/views/printer_types/index.html.erb
@@ -15,7 +15,6 @@
 
     <div class="mt-5">
       <div class="text-center"><%= link_to 'New Printer Model', new_printer_type_path, class: 'btn btn-success mb-3' %></div>
-
       <table class="table table-striped">
         <thead class="table-primary text-center">
           <th>Model</th>

--- a/app/views/printer_types/index.html.erb
+++ b/app/views/printer_types/index.html.erb
@@ -30,10 +30,13 @@
             <td><%= pt.name %></td>
             <td><%= pt.short_form.empty? ? 'None' : pt.short_form %></td>
             <td><%= pt.printers.length %></td>
-            <td><%= pt.available ? 'Yes' : 'No' %></td>
+            <td><i class="fa <%= pt.available ? 'fa-check text-success' : 'fa-times text-danger' %>"></i> <%= pt.available ? 'Yes' : 'No' %></td>
             <td class="d-flex flex-column align-items-center gap-1">
-              <%= link_to 'Edit', edit_printer_type_path(pt.id), class: 'btn btn-secondary' %>
-              <%= button_to 'Delete', printer_type_path(pt.id), method: :delete, class: 'btn btn-danger', data: { confirm: "Are you sure you want to delete this printer model AND all of it's associated printers" } if @user.admin? %>
+              <div class="btn-group">
+                <%= button_to((pt.available ? 'Disable' : 'Enable'), printer_type_path(pt, printer_type: { available: !pt.available }), method: :patch, class: "btn #{pt.available ? 'btn-danger' : 'btn-success'}") %>
+                <%= link_to 'Edit', edit_printer_type_path(pt.id), class: 'btn btn-secondary' %>
+                <%= button_to 'Delete', printer_type_path(pt.id), method: :delete, class: 'btn btn-danger', data: { confirm: "Are you sure you want to delete this printer model AND all of it's associated printers" } if @user.admin? %>
+              </div>
             </td>
           </tr>
         <% end %>

--- a/app/views/printer_types/index.html.erb
+++ b/app/views/printer_types/index.html.erb
@@ -21,6 +21,7 @@
           <th>Model</th>
           <th>Short Form</th>
           <th>Number of Printers</th>
+          <th>Is Available?</th>
           <th>Actions</th>
         </thead>
         <tbody>
@@ -29,6 +30,7 @@
             <td><%= pt.name %></td>
             <td><%= pt.short_form.empty? ? 'None' : pt.short_form %></td>
             <td><%= pt.printers.length %></td>
+            <td><%= pt.available ? 'Yes' : 'No' %></td>
             <td class="d-flex flex-column align-items-center gap-1">
               <%= link_to 'Edit', edit_printer_type_path(pt.id), class: 'btn btn-secondary' %>
               <%= button_to 'Delete', printer_type_path(pt.id), method: :delete, class: 'btn btn-danger', data: { confirm: "Are you sure you want to delete this printer model AND all of it's associated printers" } if @user.admin? %>

--- a/app/views/printers/_send_print_failed_form.html.erb
+++ b/app/views/printers/_send_print_failed_form.html.erb
@@ -6,7 +6,7 @@
         <%= fields.label :username, 'Print Owner name', class: 'form-label' %>
         <%= fields.select :username, '', {}, { id: 'user_dashboard_select', class: 'form-label form-select', required: true } %>
         <%= fields.label :printer_number, 'Printer Number', class: 'form-label' %>
-        <%= fields.select :printer_number, options_for_select(Printer.all.map { |p| [p.number, p.number] }), { selected: '' }, { id: 'printerNumberSelect', class: 'form-control form-select', required: true } %>
+        <%= fields.select :printer_number, options_for_select(Printer.all.map { |p| [p.name, p.id] }), { selected: '' }, { id: 'printerNumberSelect', class: 'form-control form-select', required: true } %>
         <%= fields.label :staff_notes, 'Staff notes (optional):', class: 'form-label' %>
         <%#= fields.text_area :staff_notes, class: 'form-control'  %>
         <%# NOTE: doing fields.trix_editor gives an exception here, not sure why %>

--- a/app/views/printers/_send_print_failed_form.html.erb
+++ b/app/views/printers/_send_print_failed_form.html.erb
@@ -1,6 +1,8 @@
-<h2>Send Print Failed Messages</h2>
 <%= form_with url: send_print_failed_message_to_user_printers_path, method: :patch do |f| %>
     <%= fields_for :print_failed_message do |fields| %>
+        <% if local_assigns[:sent_from] or true %>
+            <%= fields.hidden_field :sent_from, value: sent_from %>
+        <% end %>
         <%= fields.label :username, 'Print Owner name', class: 'form-label' %>
         <%= fields.select :username, '', {}, { id: 'user_dashboard_select', class: 'form-label form-select', required: true } %>
         <%= fields.label :printer_number, 'Printer Number', class: 'form-label' %>
@@ -8,7 +10,7 @@
         <%= fields.label :staff_notes, 'Staff notes (optional):', class: 'form-label' %>
         <%#= fields.text_area :staff_notes, class: 'form-control'  %>
         <%# NOTE: doing fields.trix_editor gives an exception here, not sure why %>
-        <%= trix_editor_tag 'print_failed_message[staff_notes]' %>
+        <%= trix_editor_tag 'print_failed_message[staff_notes]', {}, { id: 'print_failed_message_staff_notes', class: 'form-control' } %>
     <% end %>
     <%= f.submit 'Send message', class: 'btn btn-primary' %>
 <% end %>

--- a/app/views/printers/_send_print_failed_form.html.erb
+++ b/app/views/printers/_send_print_failed_form.html.erb
@@ -1,0 +1,15 @@
+<h2>Send Print Failed Messages</h2>
+<%= form_with url: send_print_failed_message_to_user_printers_path, method: :patch do |f| %>
+    <%= fields_for :print_failed_message do |fields| %>
+        <%= fields.label :username, 'Print Owner name', class: 'form-label' %>
+        <%= fields.select :username, '', {}, { id: 'user_dashboard_select', class: 'form-label form-select', required: true } %>
+        <%= fields.label :printer_number, 'Printer Number', class: 'form-label' %>
+        <%= fields.select :printer_number, options_for_select(Printer.all.map { |p| [p.number, p.number] }), { selected: '' }, { id: 'printerNumberSelect', class: 'form-control form-select', required: true } %>
+        <%= fields.label :staff_notes, 'Staff notes (optional):', class: 'form-label' %>
+        <%#= fields.text_area :staff_notes, class: 'form-control'  %>
+        <%= trix_editor_tag 'print_failed_message[staff_notes]' %>
+    <% end %>
+    <%= f.submit 'Send message', class: 'btn btn-primary' %>
+<% end %>
+
+<%= vite_javascript_tag 'staff_dashboard_search', 'data-turbo-track': 'reload' %>

--- a/app/views/printers/_send_print_failed_form.html.erb
+++ b/app/views/printers/_send_print_failed_form.html.erb
@@ -7,6 +7,7 @@
         <%= fields.select :printer_number, options_for_select(Printer.all.map { |p| [p.number, p.number] }), { selected: '' }, { id: 'printerNumberSelect', class: 'form-control form-select', required: true } %>
         <%= fields.label :staff_notes, 'Staff notes (optional):', class: 'form-label' %>
         <%#= fields.text_area :staff_notes, class: 'form-control'  %>
+        <%# NOTE: doing fields.trix_editor gives an exception here, not sure why %>
         <%= trix_editor_tag 'print_failed_message[staff_notes]' %>
     <% end %>
     <%= f.submit 'Send message', class: 'btn btn-primary' %>

--- a/app/views/printers/index.html.erb
+++ b/app/views/printers/index.html.erb
@@ -43,41 +43,4 @@
     <% end %>
   </div>
 
-  <div class="mb-4">
-    <h2 class="text-center">All Printers</h2>
-    <div class="accordion">
-      <% @printers_by_type.each do |printer_type, printers| %>
-        <div class="accordion-item">
-          <h3 class="accordion-header">
-            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-<%= printer_type.id %>" aria-expanded="false" aria-controls="collapse-<%= printer_type.id %>">
-              <%= printer_type.name %>
-            </button>
-          </h3>
-          <div id="collapse-<%= printer_type.id %>", class="accordion accordion-collapse collapse">
-            <table class="table table-striped">
-              <thead class="table-primary">
-                <tr>
-                  <td class="name-header">Name</td>
-                  <td>Action</td>
-                </tr>
-              </thead>
-              <tbody>
-                <% printers.each do |printer| %>
-                  <tr>
-                    <td><%= printer.name %></td>
-                    <td>
-                      <div class="btn-group" role="group" aria-label="Printer actions">
-                        <%= button_to 'Delete', remove_printer_printers_path, params: { remove_printer: printer.id },
-                                                                              data: { confirm: "Are you sure you want to delete #{printer.name}?" }, class: 'btn btn-danger' %>
-                      </div>
-                    </td>
-                  </tr>
-                <% end %>
-              </tbody>
-            </table>
-          </div>
-        </div>
-      <% end %>
-    </div>
-  </div>
 </section>

--- a/app/views/printers/index.html.erb
+++ b/app/views/printers/index.html.erb
@@ -17,7 +17,7 @@
     <%= form_for @printer, url: { controller: 'printers', action: 'add_printer' } do |f| %>
       <div class="mb-3">
         <%= label_tag :model_id, 'Printer Model', class: 'form-label' %><br>
-        <%= select_tag(:model_id, options_for_select(@printer_models), class: 'form-control form-select') %>
+        <%= select_tag(:model_id, options_for_select(@printer_models, selected: params[:model_id]), class: 'form-control form-select') %>
       </div>
 
       <div class="mb-3">
@@ -41,5 +41,43 @@
 
       <%= f.submit 'Remove', class: 'btn btn-primary' %>
     <% end %>
+  </div>
+
+  <div class="mb-4">
+    <h2 class="text-center">All Printers</h2>
+    <div class="accordion">
+      <% @printers_by_type.each do |printer_type, printers| %>
+        <div class="accordion-item">
+          <h3 class="accordion-header">
+            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-<%= printer_type.id %>" aria-expanded="false" aria-controls="collapse-<%= printer_type.id %>">
+              <%= printer_type.name %>
+            </button>
+          </h3>
+          <div id="collapse-<%= printer_type.id %>", class="accordion accordion-collapse collapse">
+            <table class="table table-striped">
+              <thead class="table-primary">
+                <tr>
+                  <td class="name-header">Name</td>
+                  <td>Action</td>
+                </tr>
+              </thead>
+              <tbody>
+                <% printers.each do |printer| %>
+                  <tr>
+                    <td><%= printer.name %></td>
+                    <td>
+                      <div class="btn-group" role="group" aria-label="Printer actions">
+                        <%= button_to 'Delete', remove_printer_printers_path, params: { remove_printer: printer.id },
+                                                                              data: { confirm: "Are you sure you want to delete #{printer.name}?" }, class: 'btn btn-danger' %>
+                      </div>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      <% end %>
+    </div>
   </div>
 </section>

--- a/app/views/printers/index.html.erb
+++ b/app/views/printers/index.html.erb
@@ -22,7 +22,10 @@
 
       <div class="mb-3">
         <%= f.label 'Printer Number', class: 'form-label' %>
-        <%= f.text_field :number, class: 'form-control' %>
+        <div class="input-group">
+          <div class="input-group-text"><span id="newPrinterCode">PrinterCode</span>-</div>
+          <%= f.text_field :number, class: 'form-control' %>
+        </div>
       </div>
 
       <%= f.submit 'Add', class: 'btn btn-primary' %>

--- a/app/views/printers/staff_printers.html.erb
+++ b/app/views/printers/staff_printers.html.erb
@@ -13,7 +13,7 @@
       </div>
     <% end %>
 
-    <% @printer_types.each do |pt| %>
+    <% @printer_types.filter(&:available).each do |pt| %>
       <div>
         <h2><%= pt.name %></h2>
         <% latest_session = Printer.get_last_model_session(pt.name) %>
@@ -35,7 +35,11 @@
           </div>
         <% end %>
       </div>
-
+    <% end %>
+    <hr />
+    <h2>Unavailable printers:</h2>
+    <% @printer_types.reject(&:available).each do |pt| %>
+      <p><s><%= pt.name %></s></p>
     <% end %>
   </div>
 </section>

--- a/app/views/printers/staff_printers.html.erb
+++ b/app/views/printers/staff_printers.html.erb
@@ -1,5 +1,5 @@
+<% provide(:title, 'Manage 3D-Printers Usage') %>
 <section class="padding mt-4">
-
     <div class="title">Manage 3D-Printers Usage</div>
 
     <div class="text-center my-3 d-flex flex-row justify-content-center align-items-center gap-2">
@@ -37,7 +37,9 @@
       </div>
     <% end %>
     <hr />
-    <h2>Unavailable printers:</h2>
+    <%= render partial: 'printers/send_print_failed_form' %>
+    <hr />
+    <h2>Unavailable printers</h2>
     <% @printer_types.reject(&:available).each do |pt| %>
       <p><s><%= pt.name %></s></p>
     <% end %>

--- a/app/views/printers/staff_printers.html.erb
+++ b/app/views/printers/staff_printers.html.erb
@@ -37,7 +37,8 @@
       </div>
     <% end %>
     <hr />
-    <%= render partial: 'printers/send_print_failed_form' %>
+    <h2 id="failedPrintHeader">Send Print Failed Emails</h2>
+    <%= render partial: 'printers/send_print_failed_form', locals: { sent_from: 'printers' } %>
     <hr />
     <h2>Unavailable printers</h2>
     <% @printer_types.reject(&:available).each do |pt| %>

--- a/app/views/printers/staff_printers.html.erb
+++ b/app/views/printers/staff_printers.html.erb
@@ -1,49 +1,91 @@
 <% provide(:title, 'Manage 3D-Printers Usage') %>
 <section class="padding mt-4">
-    <div class="title">Manage 3D-Printers Usage</div>
+  <div class="title">Manage 3D-Printers Usage</div>
 
+  <div class="text-center my-3 d-flex flex-row justify-content-center align-items-center gap-2">
+    <%= link_to 'View Last Updates All 3D-Printers', staff_printers_updates_printers_path, class: 'btn btn-secondary' %>
+  </div>
+
+  <% if @user.admin? %>
     <div class="text-center my-3 d-flex flex-row justify-content-center align-items-center gap-2">
-      <%= link_to 'View Last Updates All 3D-Printers', staff_printers_updates_printers_path, class: 'btn btn-secondary' %>
+      <%= link_to 'Manage Printers', printers_path, class: 'btn btn-primary' %>
+      <%= link_to 'Manage Printer Models', printer_types_path, class: 'btn btn-primary' %>
     </div>
+  <% end %>
 
-    <% if @user.admin? %>
-      <div class="text-center my-3 d-flex flex-row justify-content-center align-items-center gap-2">
-        <%= link_to 'Manage Printers', printers_path, class: 'btn btn-primary' %>
-        <%= link_to 'Manage Printer Models', printer_types_path, class: 'btn btn-primary' %>
-      </div>
-    <% end %>
-
-    <% @printer_types.filter(&:available).each do |pt| %>
-      <div>
-        <h2><%= pt.name %></h2>
-        <% latest_session = Printer.get_last_model_session(pt.name) %>
-        <% if latest_session.present? %>
-          <div class="mb-2"><%= "Last Update: Printer Number: #{latest_session.printer.number} |
-                User: #{latest_session.user.username.capitalize}" %></div>
-        <% end %>
-        <%= form_for :printer, url: { controller: 'printers', action: 'link_printer_to_user' }, method: :patch do |f| %>
-          <div class="row mb-3">
-            <div class="col-md-5">
-              <%= f.select(:printer_id, pt.printers.order(number: :asc).map { |p| [p.name, p.id] }, { prompt: 'Choose Number...' }, { class: 'link_pp form-control form-select', id: 'options' }) %>
-            </div>
-            <div class="col-md-5">
-              <%= f.select(:user_id, @list_users, { prompt: 'Choose User...' }, { class: 'link_pp form-control form-select', id: pt.name.gsub(' ', '_') }) %>
-            </div>
-            <div class="col-md-2 justify-content-center align-self-center">
-              <%= f.submit 'Submit', class: 'btn btn-secondary' %>
-            </div>
+  <% @printer_types.filter(&:available).each do |pt| %>
+    <div>
+      <h2><%= pt.name %></h2>
+      <% latest_session = Printer.get_last_model_session(pt.name) %>
+      <% if latest_session.present? %>
+        <div class="mb-2"><%= "Last Update: Printer Number: #{latest_session.printer.number} |
+                           User: #{latest_session.user.username.capitalize}" %></div>
+      <% end %>
+      <%= form_for :printer, url: { controller: 'printers', action: 'link_printer_to_user' }, method: :patch do |f| %>
+        <div class="row mb-3">
+          <div class="col-md-5">
+            <%= f.select(:printer_id, pt.printers.order(number: :asc).map { |p| [p.name + (p.maintenance ? ' - Maintenance' : ''), p.id] }, { prompt: 'Choose Number...' }, { class: 'link_pp form-control form-select', id: 'options' }) %>
           </div>
-        <% end %>
-      </div>
-    <% end %>
-    <hr />
-    <h2 id="failedPrintHeader">Send Print Failed Emails</h2>
-    <%= render partial: 'printers/send_print_failed_form', locals: { sent_from: 'printers' } %>
-    <hr />
-    <h2>Unavailable printers</h2>
-    <% @printer_types.reject(&:available).each do |pt| %>
-      <p><s><%= pt.name %></s></p>
-    <% end %>
+          <div class="col-md-5">
+            <%= f.select(:user_id, @list_users, { prompt: 'Choose User...' }, { class: 'link_pp form-control form-select', id: pt.name.gsub(' ', '_') }) %>
+          </div>
+          <div class="col-md-2 justify-content-center align-self-center">
+            <%= f.submit 'Submit', class: 'btn btn-secondary' %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+  <hr />
+  <h2 id="failedPrintHeader">Send Print Failed Emails</h2>
+  <%= render partial: 'printers/send_print_failed_form', locals: { sent_from: 'printers' } %>
+  <hr />
+  <h2>Unavailable printers</h2>
+  <% @printer_types.reject(&:available).each do |pt| %>
+    <p><s><%= pt.name %></s></p>
+  <% end %>
+  <hr />
+  <div class="mb-4">
+    <h2 class="text-center">All Printers</h2>
+    <div class="accordion">
+      <% @printers_by_type.each do |printer_type, printers| %>
+        <div class="accordion-item">
+          <h3 class="accordion-header">
+            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-<%= printer_type.id %>" aria-expanded="false" aria-controls="collapse-<%= printer_type.id %>">
+              <%= printer_type.name %>
+            </button>
+          </h3>
+          <div id="collapse-<%= printer_type.id %>", class="accordion accordion-collapse collapse">
+            <table class="table table-striped">
+              <thead class="table-primary">
+                <tr>
+                  <td>Name</td>
+                  <td>Maintenance?</td>
+                  <td>Action</td>
+                </tr>
+              </thead>
+              <tbody>
+                <% printers.each do |printer| %>
+                  <tr>
+                    <td><%= printer.name %></td>
+                    <td><i class="fa <%= printer.maintenance ? 'fa-check text-success' : 'fa-times text-danger' %>"></i> <%= printer.maintenance ? 'Yes' : 'No' %></td>
+                    <td>
+                      <div class="btn-group" role="group" aria-label="Printer actions">
+                        <%#= button_to 'Delete', remove_printer_printers_path, params: { remove_printer: printer.id },
+                                      data: { confirm: "Are you sure you want to delete #{printer.name}?" }, class: 'btn btn-danger' if current_user.admin?%>
+                        <%= button_to "#{printer.maintenance ? 'Unflag' : 'Flag'} Maintenance",
+                                      printer_path(printer, printer: { maintenance: !printer.maintenance }), method: :patch,
+                                                                                                             class: 'btn btn-primary' %>
+                      </div>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      <% end %>
+    </div>
   </div>
 </section>
 <%= vite_javascript_tag 'staff_printers', 'data-turbo-track': 'reload' %>

--- a/app/views/printers/staff_printers.html.erb
+++ b/app/views/printers/staff_printers.html.erb
@@ -24,7 +24,7 @@
         <%= form_for :printer, url: { controller: 'printers', action: 'link_printer_to_user' }, method: :patch do |f| %>
           <div class="row mb-3">
             <div class="col-md-5">
-              <%= f.select(:printer_id, pt.printers.order(number: :asc).pluck(:number, :id), { prompt: 'Choose Number...' }, { class: 'link_pp form-control form-select', id: 'options' }) %>
+              <%= f.select(:printer_id, pt.printers.order(number: :asc).map { |p| [p.name, p.id] }, { prompt: 'Choose Number...' }, { class: 'link_pp form-control form-select', id: 'options' }) %>
             </div>
             <div class="col-md-5">
               <%= f.select(:user_id, @list_users, { prompt: 'Choose User...' }, { class: 'link_pp form-control form-select', id: pt.name.gsub(' ', '_') }) %>

--- a/app/views/printers/staff_printers_updates.html.erb
+++ b/app/views/printers/staff_printers_updates.html.erb
@@ -20,7 +20,7 @@
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div class="modal-body">
-            <%= render partial: 'printers/send_print_failed_form' %>
+            <%= render partial: 'printers/send_print_failed_form', locals: { sent_from: 'updates' } %>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
@@ -60,7 +60,7 @@
                 <td><%= link_to last_session.user.username, user_path(last_session.user.username) %></td>
                 <td><%= last_session&.created_at&.strftime('%a, %d %b %Y at %I:%M%p') %></td>
                 <td><%= last_session.in_use? ? 'Yes' : 'No' %></td>
-                <td><button type="button" class="btn btn-danger btn-block" data-bs-toggle="modal" data-bs-target="#printFailedModal">Notify failed</button></td>
+                <td><button type="button" class="btn btn-danger btn-block print-failed-button" data-bs-toggle="modal" data-bs-target="#printFailedModal" data-username="<%= last_session.user.username %>" data-printer-number="<%= Printer.find(printer_id).number %>">Notify failed</button></td>
               <% end %>
             </tr>
           <% end %>
@@ -70,3 +70,4 @@
     <% end %>
   </div>
 </section>
+<%= vite_javascript_tag 'staff_printers_updates' %>

--- a/app/views/printers/staff_printers_updates.html.erb
+++ b/app/views/printers/staff_printers_updates.html.erb
@@ -12,6 +12,23 @@
       </div>
     <% end %>
 
+    <div class="modal" tabindex="-1" id="printFailedModal" aria-labelledby="modal-title" >
+      <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h1 class="modal-title" id="modal-title">Send print failed email</h1>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <%= render partial: 'printers/send_print_failed_form' %>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <% @printer_types.each_with_index do |pt, index| %>
       <div class="mb-3">
         <h2><%= pt.name %></h2>
@@ -21,6 +38,7 @@
           <th>User<span onclick="sortTable('table-<%= index %>', 1)"><%= fa_icon('arrow-down') %></span></th>
           <th>Time<span onclick="sortTable('table-<%= index %>', 2)"><%= fa_icon('arrow-down') %></span></th>
           <th>In Use<span onclick="sortTable('table-<%= index %>', 3)"><%= fa_icon('arrow-down') %></span></th>
+          <th>Action</th>
           </thead>
           <tbody>
           <% Printer.get_printer_ids(pt.name).sort_by do |printer_id|
@@ -42,6 +60,7 @@
                 <td><%= link_to last_session.user.username, user_path(last_session.user.username) %></td>
                 <td><%= last_session&.created_at&.strftime('%a, %d %b %Y at %I:%M%p') %></td>
                 <td><%= last_session.in_use? ? 'Yes' : 'No' %></td>
+                <td><button type="button" class="btn btn-danger btn-block" data-bs-toggle="modal" data-bs-target="#printFailedModal">Notify failed</button></td>
               <% end %>
             </tr>
           <% end %>

--- a/app/views/printers/staff_printers_updates.html.erb
+++ b/app/views/printers/staff_printers_updates.html.erb
@@ -42,7 +42,8 @@
           </thead>
           <tbody>
           <% Printer.get_printer_ids(pt.name).sort_by do |printer_id|
-            Printer.find(printer_id).name
+            printer = Printer.find(printer_id)
+            [printer.name.length, printer.name]
           end.each do |printer_id|
             last_session = Printer.get_last_number_session(printer_id)
           %>

--- a/app/views/printers/staff_printers_updates.html.erb
+++ b/app/views/printers/staff_printers_updates.html.erb
@@ -42,18 +42,14 @@
           </thead>
           <tbody>
           <% Printer.get_printer_ids(pt.name).sort_by do |printer_id|
-            number_str = Printer.find(printer_id).number
-            prefix, main_part = number_str.split(' - ', 2)
-            numeric_part = main_part.scan(/\d+/)[0].to_i
-            alphabetic_part = main_part.gsub(/\d+/, '')
-            [prefix, alphabetic_part, numeric_part]
+            Printer.find(printer_id).name
           end.each do |printer_id|
             last_session = Printer.get_last_number_session(printer_id)
           %>
             <tr>
-              <td><%= Printer.find(printer_id).number %></td>
+              <td><%= Printer.find(printer_id).name %></td>
               <% if last_session.nil? %>
-                <% 3.times do %>
+                <% 4.times do %>
                   <td>-------</td>
                 <% end %>
               <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -328,6 +328,7 @@ Rails.application.routes.draw do
 
         # post 'rename_category'
         patch "update_job_order_processed"
+        patch "update_print_failed_message"
         post "remove_category"
         post "remove_area"
         post "add_equipment"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,6 +114,7 @@ Rails.application.routes.draw do
       get :staff_printers
       get :staff_printers_updates
       patch :link_printer_to_user
+      patch :send_print_failed_message_to_user
       post :add_printer
       post :remove_printer
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,7 +109,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :printers, only: %i[index] do
+  resources :printers, only: %i[index update] do
     collection do
       get :staff_printers
       get :staff_printers_updates

--- a/db/migrate/20240725202442_add_available_to_printer_types.rb
+++ b/db/migrate/20240725202442_add_available_to_printer_types.rb
@@ -1,0 +1,5 @@
+class AddAvailableToPrinterTypes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :printer_types, :available, :boolean, default: true
+  end
+end

--- a/db/migrate/20240728175636_remove_shortform_from_printer_numbers.rb
+++ b/db/migrate/20240728175636_remove_shortform_from_printer_numbers.rb
@@ -1,0 +1,11 @@
+class RemoveShortformFromPrinterNumbers < ActiveRecord::Migration[7.0]
+  def change
+    reversible do |direction|
+      direction.up do
+        Printer.all.each do |p|
+          p.update(number: p.number.split("-").last.squish) # remove short form
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20240801135848_add_maintenance_to_printers.rb
+++ b/db/migrate/20240801135848_add_maintenance_to_printers.rb
@@ -1,0 +1,5 @@
+class AddMaintenanceToPrinters < ActiveRecord::Migration[7.0]
+  def change
+    add_column :printers, :maintenance, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_25_202442) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_28_175636) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_23_173424) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_25_202442) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -729,6 +729,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_23_173424) do
     t.string "short_form", default: ""
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "available", default: true
   end
 
   create_table "printers", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_28_175636) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_01_135848) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -737,6 +737,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_28_175636) do
     t.datetime "updated_at", precision: nil, null: false
     t.string "number"
     t.bigint "printer_type_id"
+    t.boolean "maintenance", default: false
     t.index ["printer_type_id"], name: "index_printers_on_printer_type_id"
   end
 

--- a/doc/mail.md
+++ b/doc/mail.md
@@ -1,0 +1,33 @@
+# Sending mail using mailers
+
+A lot of the old mails are simply copy pastes of each other, the print_failed email from `MsrMailer` is the only one that uses the `msr_mailer` layout. Because there's a ton of emails and not all of them might fit nicely in the layout, we selectively add them with a format block. It should've been an `application_mailer` layout to cover ALL emails. Someone should move all emails to that layout and have it global instead :^)
+
+`MsrMailer` (or MakerSpaceRepo Mailer) is the big mailer that contains almost all mails, from welcome to restore passwords, proficient project results and print jobs. There's other smaller ones for job orders, booking, etc. Feel free to create new mailers, but make sure you create a layout for them first. Tests are important for those, since admin and staff almost never receive these emails and users are quick to notice something broken.
+
+Rails has support for multipart email, or sending both html and text in the same email. We should do that sometime, maybe do `strip_tags(@message)` in the body. It's mostly an accessibility thing since some users might prefer text emails instead of html. Otherwise, enabling text in an email will give a 'template missing error'.
+
+We have two editable mail templates, the Job Order email and the print failed email. Both are being stored in the `JobOrderMessage` table, because previously it was a table containing a single row with the job order mail template. Each message has a unique name and is retrieved with a scope and formatted with a function.
+
+## Mail basics
+
+Mail should have a descriptive subject that explains the entire mail before the user even opens it; when viewed from an inbox list or a phone notification drawer. The body should repeat the subject, and elaborate on what actions the user can perform. Keep in mind not all Makerepo users are engineering students, a lot are not university students or are students from other faculties.
+
+The body should include only text and anchor links, buttons are not a good idea as they are not supported by any version of Outlook on Windows. See below.
+
+All mail should have a reason for sending at the bottom, print_failed provides a `:why_received` for the `msr_mailer` layout.
+
+Any mail send is done similar to `MsrMailer.welcome_mail(user).deliver_now`. If the `deliver_now` method isn't called, it'll be stored in a job queue for later delivery. I'm not sure if we have a cron job or rake task for that setup.
+
+## Email editing
+
+Some emails have editable messages, like the job order message and the printer falied message. These messages are usually made editable with a `trix_editor` tag. Messages are stored as html fragments in `JobOrderMessage` and each have a scope for quick access. They also have a formatting method that takes in parameters and returns a string containing html tags, or the unformatted message.
+
+## Testing email
+
+To test email on staging, we have the `letter_opener` gem installed as a mail handler.
+
+To test emails, open a rails console (`rails c` in a terminal or `projectile-rails-console` in emacs) and do `MsrMailer.welcome_email(User.find_by_id(25)).deliver_now`. This will simulate a mail delivery and open it in your browser. All generated emails are stored in `tmp/letter_opener/`.
+
+## Email HTML
+
+Email HTML is **very** broken, see https://www.caniemail.com/ for what little you can use. More generally, inline styles only and table layouts and simple text are the only thing that works here. University uses outlook for mail, and outlook on windows uses Word as a rendering engine, while you're probably using an actual web browser. So be very careful with layout, and don't a lot of fancy css for accessibility reasons too.

--- a/doc/useful_terminal_commands.md
+++ b/doc/useful_terminal_commands.md
@@ -31,7 +31,7 @@ ssh deploy@wiki-server.makerepo.com
 rails c -e development
 ```
 
-If the console exits after each exception, try doing `$SAFE=0` first
+If the console exits after each exception, try doing `$SAFE=0` first or place it in your `.pryrc` file
 
 5. Launch Rails Console (Staging/Production Environment)
 

--- a/spec/controllers/printer_types_controller_spec.rb
+++ b/spec/controllers/printer_types_controller_spec.rb
@@ -102,10 +102,8 @@ RSpec.describe PrinterTypesController, type: :controller do
         session[:user_id] = @admin.id
         session[:expires_at] = Time.zone.now + 10_000
 
-        @um2p_1 =
-          create(:printer, printer_type_id: @um2p.id, number: "UM2P - 1")
-        @um2p_2 =
-          create(:printer, printer_type_id: @um2p.id, number: "UM2P - 2")
+        @um2p_1 = create(:printer, printer_type_id: @um2p.id, number: "1")
+        @um2p_2 = create(:printer, printer_type_id: @um2p.id, number: "2")
       end
 
       it "should update the printer type and its short form" do
@@ -119,7 +117,8 @@ RSpec.describe PrinterTypesController, type: :controller do
               }
 
         expect(flash[:notice]).to eq("Successfully updated printer model")
-        expect(Printer.find(@um2p_1.id).number).to eq("UM2+ - 1")
+        expect(Printer.find(@um2p_1.id).name).to eq("UM2+ - 1")
+        expect(Printer.find(@um2p_2.id).name).to eq("UM2+ - 2")
       end
     end
   end

--- a/spec/factories/printer_types.rb
+++ b/spec/factories/printer_types.rb
@@ -1,5 +1,10 @@
 FactoryBot.define do
   factory :printer_type do
+    # Because setting the same association twice creates it twice
+    # unless we create ourselves
+    initialize_with do
+      PrinterType.find_or_create_by(name: name, short_form: short_form)
+    end
     trait :UM2P do
       name { "Ultimaker 2+" }
       short_form { "UM2P" }

--- a/spec/factories/printers.rb
+++ b/spec/factories/printers.rb
@@ -1,22 +1,28 @@
 FactoryBot.define do
   factory :printer do
     trait :UM2P_01 do
-      number { "UM2P - 01" }
+      association :printer_type, :UM2P
+      number { "01" }
     end
     trait :UM2P_02 do
-      number { "UM2P - 02" }
+      association :printer_type, :UM2P
+      number { "02" }
     end
     trait :UM3_01 do
-      number { "UM3 - 01" }
+      association :printer_type, :UM3
+      number { "01" }
     end
     trait :RPL2_01 do
-      number { "RPL2 - 01" }
+      association :printer_type, :RPL2
+      number { "01" }
     end
     trait :RPL2_02 do
-      number { "RPL2 - 02" }
+      association :printer_type, :RPL2
+      number { "02" }
     end
     trait :dremel_10_17 do
-      number { "10 - 17" }
+      association :printer_type, :Dremel
+      number { "17" }
     end
   end
 end

--- a/spec/models/printer_spec.rb
+++ b/spec/models/printer_spec.rb
@@ -7,50 +7,18 @@ RSpec.describe Printer, type: :model do
     @pt_3 = create(:printer_type, :Random)
     @pt_4 = create(:printer_type, :Random)
 
-    @pt_1_1 =
-      create(
-        :printer,
-        number: "#{@pt_1.short_form} - 1",
-        printer_type_id: @pt_1.id
-      )
-    @pt_1_2 =
-      create(
-        :printer,
-        number: "#{@pt_1.short_form} - 2",
-        printer_type_id: @pt_1.id
-      )
-    @pt_2_1 =
-      create(
-        :printer,
-        number: "#{@pt_2.short_form} - 1",
-        printer_type_id: @pt_2.id
-      )
-    @pt_3_1 =
-      create(
-        :printer,
-        number: "#{@pt_3.short_form} - 1",
-        printer_type_id: @pt_3.id
-      )
-    @pt_3_2 =
-      create(
-        :printer,
-        number: "#{@pt_3.short_form} - 2",
-        printer_type_id: @pt_3.id
-      )
-    @pt_4_1 =
-      create(
-        :printer,
-        number: "#{@pt_4.short_form} - 1",
-        printer_type_id: @pt_4.id
-      )
+    @pt_1_1 = create(:printer, number: "1", printer_type_id: @pt_1.id)
+    @pt_1_2 = create(:printer, number: "2", printer_type_id: @pt_1.id)
+    @pt_2_1 = create(:printer, number: "1", printer_type_id: @pt_2.id)
+    @pt_3_1 = create(:printer, number: "1", printer_type_id: @pt_3.id)
+    @pt_3_2 = create(:printer, number: "2", printer_type_id: @pt_3.id)
+    @pt_4_1 = create(:printer, number: "1", printer_type_id: @pt_4.id)
   end
 
   describe "model method" do
     context "model and number" do
       it "should return the model and number" do
-        expect(@pt_1_1.model_and_number).to eq(
-          "#{@pt_1.name}; Number #{@pt_1_1.number}"
-        )
+        expect(@pt_1_1.model_and_number).to eq("#{@pt_1.name}; #{@pt_1_1.name}")
       end
     end
 


### PR DESCRIPTION
New "Print failed" mailer method, takes a user and a printer and an optional staff notes string. Editable from admin page and sent from staff_printers or staff_printer_updates

Staff can also hide printer types from staff_printers, because sometimes we just don't have them available

Also fixes job order message edit form being broken, printer numbers not inheriting from printer type, and attempt at making `MsrMailer` use a common layout. Staff printer pages have a title name for easier staff access. Some docs explaining how to use the mailer.

This thing also has a migration to remove the prefix from the number of each printer, it doesn't work on the dremel ones for some reason (?) so a manual rename from admin might be necessary

Adds a more convenient 'All Printers' list, where staff can flag a printer for maintenance. Flagging for maintenance does not disable a printer, that's more of a staff decision to make

A dubious change here is that I reused the `JobOrderMessage` table, was previously used to store a single row containing a single message for job orders. Because it didn't feel right to make a second table, name it 'email templates', and then move the job order to it. Printing is technically a job order, right? I explained that in the docs.