### PR TITLE
Destroy time period dependents

### DIFF
--- a/app/models/time_period.rb
+++ b/app/models/time_period.rb
@@ -1,5 +1,5 @@
 class TimePeriod < ApplicationRecord
-  has_many :staff_availabilities
+  has_many :staff_availabilities, dependent: :destroy
 
   default_scope -> { order(start_date: :desc) }
 


### PR DESCRIPTION
Simply delete all staff availability attached to a time period