### PR TITLE
Update github workflow to pull latest wkhtmltopdf

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,11 +59,12 @@ jobs:
           REDIS_URL: redis://localhost:6379/0
           RAILS_ENV: test
         run: |
+          sudo apt-get update
           sudo apt-get -yqq install libpq-dev
           mkdir certs && touch certs/saml.key && touch certs/saml.crt
           openssl req -x509 -newkey rsa:4096 -keyout certs/saml.key -out certs/saml.crt -days 1 -nodes -subj "/C=CA/ST=Ontario/L=Ottawa/O=uOttawa/OU=Richard L'Abbé Makerspace/CN=makerepo.com/emailAddress=travis-ci@makerepo.com"
-          wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.focal_amd64.deb
-          sudo apt install ./wkhtmltox_0.12.6-1.focal_amd64.deb
+          wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
+          sudo apt install ./wkhtmltox_0.12.6.1-2.jammy_amd64.deb
       - name: Migrate DB
         env:
           DATABASE_URL: postgres://postgres:@localhost:5432/makerspacerepo_test
@@ -78,6 +79,7 @@ jobs:
           REDIS_URL: redis://localhost:6379/0
           RAILS_ENV: test
         run: |
+
           bundle exec rails spec
       - name: Deploy Staging
         if: github.ref == 'refs/heads/staging'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
           RAILS_ENV: test
         run: |
           sudo apt-get update
-          sudo apt-get -yqq install libpq-dev
+          sudo apt-get -yqq install libpq-dev imagemagick
           mkdir certs && touch certs/saml.key && touch certs/saml.crt
           openssl req -x509 -newkey rsa:4096 -keyout certs/saml.key -out certs/saml.crt -days 1 -nodes -subj "/C=CA/ST=Ontario/L=Ottawa/O=uOttawa/OU=Richard L'Abbé Makerspace/CN=makerepo.com/emailAddress=travis-ci@makerepo.com"
           wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb


### PR DESCRIPTION
Because the older revision was expecting openssl1.1.
Also install imagemagick explicitly. Which is weird because these errors did not come up until now.