### PR TITLE
Add space-wide sharable calendar (.ics) links

### DIFF
--- a/app/controllers/staff/shared_calendars_controller.rb
+++ b/app/controllers/staff/shared_calendars_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require "date"
+
+class Staff::SharedCalendarsController < StaffAreaController
+  layout "staff_area"
+
+  def index
+     @spaces =
+      Space.all.where(
+        id: StaffSpace.where(user_id: current_user.id).pluck(:space_id)
+      )
+    @space_id = @user.space_id || Space.first.id
+  end
+ 
+  def get_calendars
+    @calendars = SharedCalendar.where(
+      space_id: @user.space_id || Space.first.id
+    )
+
+    render json: {
+      calendars: @calendars.map do |calendar| 
+        {
+          name: calendar.name,
+          url: calendar.url,
+        }
+      end
+    }
+
+  end
+
+  private
+  def set_default_space
+    @space_id = current_user.space_id || Space.first.id
+  end
+end
+
+
+

--- a/app/javascript/entrypoints/shared_calendars.js
+++ b/app/javascript/entrypoints/shared_calendars.js
@@ -1,0 +1,48 @@
+document.addEventListener("DOMContentLoaded", async () => {
+  const calContainer = document.getElementById("cal-container");
+
+  // create dom element
+  const calendarElement = document.createElement("add-to-calendar-button");
+
+  try {
+    const res = await fetch("/staff/shared_calendars/get_calendars");
+
+    // for each calendar, create an h3 with name and create a button
+    const { calendars } = await res.json();
+
+    if (!calendars || calendars.length === 0) {
+      const h3 = document.createElement("h3");
+      h3.textContent = "No calendars available";
+      calContainer.appendChild(h3);
+      return;
+    }
+
+    calendars.forEach((cal) => {
+      const h3 = document.createElement("h3");
+      h3.textContent = cal.name;
+      h3.classList.add("mt-4");
+      calContainer.appendChild(h3);
+
+      const calendarElement = document.createElement("add-to-calendar-button");
+      calendarElement.setAttribute("name", cal.name);
+      calendarElement.setAttribute("subscribe", "");
+      calendarElement.setAttribute("icsFile", cal.url);
+      calendarElement.setAttribute(
+        "options",
+        "'Google','Apple','Outlook.com','Microsoft 365','Microsoft Teams','iCal'",
+      );
+      calendarElement.setAttribute("buttonStyle", "flat");
+      calendarElement.setAttribute("hideIconList", "");
+      calendarElement.setAttribute("buttonsList", "");
+      calendarElement.setAttribute("hideBackground", "");
+      calendarElement.setAttribute("label", "Flat and Singleton");
+      calendarElement.setAttribute("lightMode", "bodyScheme");
+
+      // append to container
+      calContainer.appendChild(calendarElement);
+    });
+  } catch (error) {
+    console.error("Error fetching shifts:", error);
+    document.getElementById("spinner").style.display = "none";
+  }
+});

--- a/app/models/shared_calendar.rb
+++ b/app/models/shared_calendar.rb
@@ -1,0 +1,3 @@
+class SharedCalendar < ApplicationRecord
+  belongs_to :space
+end

--- a/app/views/admin/spaces/edit.html.erb
+++ b/app/views/admin/spaces/edit.html.erb
@@ -188,6 +188,46 @@
   </div>
 
   <br><br>
+  
+  <h2 class="mb-3 fw-bold">Manage Shared Calendars</h2>
+
+  <%= form_with url: create_shared_calendar_admin_spaces_path(space_id: @space.id), method: :post, local: true do |form| %>
+    <div class="mb-3">
+      <%= form.text_field :name, class: "form-control", placeholder: "Calendar Name" %>
+    </div>
+
+    <div class="mb-3">
+      <%= form.text_field :url, class: "form-control", placeholder: "Calendar URL" %>
+    </div>
+
+    <div class="mb-3">
+      <%= form.submit "Create Shared Calendar", class: "btn btn-primary" %>
+    </div>
+  <% end %>
+
+  <%# display shared calendars %>
+  <div class="table-responsive">
+    <table class="table table-striped">
+      <thead class="table-primary text-center">
+      <tr>
+        <th>Calendar Name</th>
+        <th>Calendar URL</th>
+        <th>Delete Calendar</th>
+      </tr>
+      </thead>
+      <% @shared_calendars.each do |calendar| %>
+        <tr>
+          <td><%= calendar.name %></td>
+          <td><%= calendar.url %></td>
+          <td>
+            <%= button_to 'Delete', delete_shared_calendar_admin_spaces_path(space_id: @space.id, id: calendar.id), method: :delete, action: :destroy, data: { confirm: 'Are you sure you want to delete this shared calendar?' }, class: 'btn btn-danger' %>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+
+  
+  <br><br>
 
   <h2 class="mb-3 fw-bold">Manage RFID Readers</h2>
   <br>
@@ -221,7 +261,7 @@
         <th>Associate with <%= @space.name %></th>
       </tr>
       </thead>
-      <% PiReader.where(space_id: nil).each do |raspi| %>
+      <% PiReader.where(space_id: nil).find_each do |raspi| %>
         <tr>
           <td><%= raspi.pi_mac_address %></td>
           <td>unknown</td>

--- a/app/views/layouts/_staff_area_header.html.erb
+++ b/app/views/layouts/_staff_area_header.html.erb
@@ -12,6 +12,7 @@
         <li class="nav-item"><%= link_to 'Shifts', staff_shifts_schedule_index_path, class: 'nav-link' %></li>
         <li class="nav-item"><%= link_to 'Sign in kiosk', kiosk_index_path, class: 'nav-link' %></li>
         <li class="nav-item"><%= link_to 'Makerstore links', staff_makerstore_links_path, class: 'nav-link' %></li>
+        <li class="nav-item"><%= link_to 'Shared Calendars', staff_shared_calendars_path, class: 'nav-link' %></li>
       </ul>
     </div>
   </div>

--- a/app/views/staff/shared_calendars/index.html.erb
+++ b/app/views/staff/shared_calendars/index.html.erb
@@ -1,0 +1,34 @@
+<div class="my-5 vh-50">
+    <div class="col-md-12">
+      <div class="d-flex justify-content-center gap-2">
+        <%= form_tag staff_dashboard_change_space_path, method: :put do %>
+          <div class="input-group mb-3">
+            <%= label_tag :space_id, 'Space', class: 'input-group-text' %>
+            <%= select_tag :space_id, options_for_select(@spaces.pluck(:name, :id), selected: @space_id), class: 'form-select' %>
+            <%= hidden_field_tag :shifts, true %>
+            <button class="btn btn-outline-secondary" type="submit">Go</button>
+          </div>
+        <% end %>
+      </div>
+
+
+      <script src="https://cdn.jsdelivr.net/npm/add-to-calendar-button@2" async defer></script>
+
+
+      <div class="py-5" id="cal-container">
+        <h2 class="h2 fw-bold mb-3">Subscribe to <%= @spaces.find { |space| space.id == @space_id }&.name %>'s Calendar(s)</h3>
+      </div>
+
+
+      <div id='spinner' class="spinner-border" style="scale: 5; position:absolute; z-index:1000; left:50%; top:50%;" role="status">
+        <span class="visually-hidden">Loading...</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+<br>
+
+
+<%= vite_javascript_tag 'staff_shifts' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -315,6 +315,8 @@ Rails.application.routes.draw do
         delete :delete_space_hour
         post :add_training_levels
         put :update_staff_needed_calendars
+        post :create_shared_calendar
+        delete :delete_shared_calendar
       end
     end
 
@@ -452,6 +454,9 @@ Rails.application.routes.draw do
     end
     resources :shifts_schedule, except: %i[new show destroy] do
       collection { get :get_shifts }
+    end
+    resources :shared_calendars do
+      collection { get :get_calendars }
     end
 
     resources :makerstore_links, only: %i[index edit update create new] do

--- a/db/migrate/20250513145411_create_shared_calendars.rb
+++ b/db/migrate/20250513145411_create_shared_calendars.rb
@@ -1,0 +1,11 @@
+class CreateSharedCalendars < ActiveRecord::Migration[7.2]
+  def change
+    create_table :shared_calendars do |t|
+      t.string :name
+      t.string :url
+      t.references :space, null: false, foreign_key: { to_table: :"public.spaces" }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_30_210138) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_13_145411) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -577,12 +577,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_30_210138) do
     t.datetime "owned_until"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "repository_id"
-    t.string "requested_as"
     t.string "shopify_draft_order_id"
     t.index ["locker_type_id"], name: "index_locker_rentals_on_locker_type_id"
     t.index ["rented_by_id"], name: "index_locker_rentals_on_rented_by_id"
-    t.index ["repository_id"], name: "index_locker_rentals_on_repository_id"
   end
 
   create_table "locker_types", force: :cascade do |t|
@@ -976,6 +973,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_30_210138) do
     t.bigint "space_id"
     t.index ["space_id"], name: "index_shadowing_hours_on_space_id"
     t.index ["user_id"], name: "index_shadowing_hours_on_user_id"
+  end
+
+  create_table "shared_calendars", force: :cascade do |t|
+    t.string "name"
+    t.string "url"
+    t.bigint "space_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["space_id"], name: "index_shared_calendars_on_space_id"
   end
 
   create_table "shifts", force: :cascade do |t|
@@ -1381,6 +1387,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_30_210138) do
   add_foreign_key "rfids", "users"
   add_foreign_key "shadowing_hours", "spaces"
   add_foreign_key "shadowing_hours", "users"
+  add_foreign_key "shared_calendars", "spaces"
   add_foreign_key "shifts", "spaces"
   add_foreign_key "shifts", "trainings"
   add_foreign_key "space_staff_hours", "course_names"

--- a/spec/factories/shared_calendars.rb
+++ b/spec/factories/shared_calendars.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :shared_calendar do
+    name { "MyString" }
+    url { "MyString" }
+    space { nil }
+  end
+end

--- a/spec/models/shared_calendar_spec.rb
+++ b/spec/models/shared_calendar_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SharedCalendar, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Allow space admins to create shareable calendar links for staff to save

Note: currently importing `add-to-calendar-button` using a script tag. could implement the add to calendar functionality ourselves.