### PR TITLE
Block some more pages from crawlers

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -4,6 +4,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
             "uottawa-makerspace.github.io/makerepo-react-app",
             "uottawa-makerspace.github.io",
             "designday.makerepo.com",
+            %r{https://.*\.design-day-react.pages.dev},
             "app.makerepo.com",
             %r{https://.*\.makerepo-app.pages.dev}
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -9,8 +9,8 @@ User-agent: *
 Disallow: /search
 
 # Prevent assets folder, full of heavy assets
-#User-agent: *
-#Disallow: /rails/active_storage
+User-agent: *
+Disallow: /rails/active_storage
 
 User-agent: SemrushBot
 Disallow: /

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,6 +4,14 @@
 User-agent: *
 Disallow: /explore
 
+# Prevent search, nothing shows up here
+User-agent: *
+Disallow: /search
+
+# Prevent assets folder, full of heavy assets
+#User-agent: *
+#Disallow: /rails/active_storage
+
 User-agent: SemrushBot
 Disallow: /
 


### PR DESCRIPTION
There's no need for bots to access the search box. Allowing bots to access storage is also very expensive too.