### PR TITLE
Removed Booking Admin link from the admin area header. The booking ad…

### DIFF
--- a/app/views/layouts/_admin_area_header.html.erb
+++ b/app/views/layouts/_admin_area_header.html.erb
@@ -21,7 +21,6 @@
         <li class="nav-item"><%= link_to t('navbar.design_day'), admin_design_day_path, class: 'nav-link' %></li>
         <li class="nav-item"><%= link_to t('admin.announcements'), admin_announcements_path, class: 'nav-link' %></li>
         <li class="nav-item"><%= link_to t('admin.reports'), admin_report_generator_index_path, class: 'nav-link' %></li>
-        <li class="nav-item"><%= link_to t('admin.booking_admin'), sub_space_booking_index_path(anchor: 'booking-admin-tab'), class: 'nav-link' %></li>
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" href="#", id="navbarDropdown1" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <%= t('admin.trainings') %>


### PR DESCRIPTION
…min area is still fully accessible through the Makeroom (if you're an admin), so the issue should be fully fixed.