### PR TITLE
 Enable HTTPS for all connections and email-generated URLs

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,10 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
+
+  # Ensure all Action Mailer URL helpers generate HTTPS links
+  config.action_mailer.default_url_options = { host: 'makerepo.com', protocol: 'https' }
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).


### PR DESCRIPTION
This PR fixes insecure email link generation by configuring Action Mailer to use HTTPS URLs by default and Forces all web requests to redirect from HTTP to HTTPS by enabling `config.force_ssl`.

Fixes #1726
