### PR TITLE
Printers in Use Error

### DIFF
--- a/app/controllers/staff_dashboard_controller.rb
+++ b/app/controllers/staff_dashboard_controller.rb
@@ -45,6 +45,8 @@ class StaffDashboardController < StaffAreaController
           .joins(:training, training: :spaces)
           .where(trainings: { spaces: { id: space_id } })
       end
+    @printers_in_use =
+      PrinterSession.order(created_at: :desc).where(in_use: true)
     @all_user_certs = proc { |user| user.certifications }
     recent_membership = @space.signed_in_users.first.memberships.active.order(end_date: :desc).first
     recent_expiration_date = ""


### PR DESCRIPTION
The query for printers in use was needed to be repeated in the refresh_tables endpoint. This was keeping any javascript from loading on the page. In the future, this solution can be improved upon by creating before_actions for the instance variables in the staff dashboard controller to reduce the need to repeat queries.