### PR TITLE
fix the sorting issue

### DIFF
--- a/app/javascript/entrypoints/tabledata.js
+++ b/app/javascript/entrypoints/tabledata.js
@@ -6,6 +6,8 @@ DataTable.ext.errMode = "throw";
 
 document.addEventListener("turbo:load", function () {
   document.body.querySelectorAll("[data-datatable]").forEach(function (el) {
-    new DataTable(el);
+    new DataTable(el, {
+      order: [], // this makes it so Last Seen is in descending order.
+    });
   });
 });


### PR DESCRIPTION
recently signed out table is sorted to alphabetical names by default, now it should sort by last seen time by default.