### PR TITLE
Fixed minor datatable bugs on Trainings index

### DIFF
--- a/app/javascript/entrypoints/trainings.js
+++ b/app/javascript/entrypoints/trainings.js
@@ -1,4 +1,5 @@
 import TomSelect from "tom-select";
+import DataTable from "datatables.net-bs5";
 
 document.addEventListener("turbo:load", () => {
   if (document.querySelector("#training_list_of_skills_en")) {
@@ -28,4 +29,8 @@ document.addEventListener("turbo:load", () => {
       persist: false,
     });
   }
+});
+
+document.addEventListener("turbo:load", () => {
+  new DataTable("#trainings-table");
 });

--- a/app/views/admin/trainings/index.html.erb
+++ b/app/views/admin/trainings/index.html.erb
@@ -2,7 +2,7 @@
   <h2 class="text-center fw-bold py-3">Admin's Trainings Manager</h2>
   <p class="text-center"><%= link_to 'New Training', new_admin_training_path, class: 'btn btn-secondary' %></p>
   <br />
-  <table class="table table-striped mb-5" data-datatable>
+  <table id="trainings-table" class="table table-striped mb-5">
   <thead class="table-primary">
     <tr class="text-center">
       <th>Skill Type</th>


### PR DESCRIPTION
Pretty quick fix:

The datatable was being loaded in the HTML file using "data-datatables". I tried loading it in the js file and it fixed the stacking issue. The table was also being unresponsive if you went back a page sometimes. I fixed it by calling the datatable on "turbo:load".